### PR TITLE
Update README.md - practices-ng-commands

### DIFF
--- a/ng/practices-ng-commands/README.md
+++ b/ng/practices-ng-commands/README.md
@@ -120,7 +120,7 @@ In the template:
     <input formControlName="name" placeholder="Name" />
     <input formControlName="email" placeholder="Email" />
 
-    <button [puiClickCommand]="saveCommand" [disabled]="saveCommand.disabledSignal()">Save</button>
+    <button [puiClickCommand]="saveCommand">Save</button>
 </form>
 ```
 


### PR DESCRIPTION
## Description

This change updates the `practices-ng-commands` README to simplify the documented usage example for the `puiClickCommand` directive. The example button previously bound the `[disabled]` attribute manually to `saveCommand.disabledSignal()`, which is redundant because the directive already handles the disabled state internally. Removing the explicit binding keeps the documentation accurate and demonstrates the intended, more concise usage.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

No automated testing was performed as this is a documentation-only change to a single Markdown file. The updated example was reviewed for correctness against the directive's intended behavior.

## Integration Instructions

N/A
