### PR TITLE
Add `whitespace-pre-line` to readonly value of `PuibeReadonlyLabelValueComponent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Practices.Mail` Update MailKit to 4.14.1
 - `Practices.Syncfusion.Excel` Update Syncfusion.XlsIO.Net.Core to 31.2.18
 - `Practices.Syncfusion.Pdf` Update Syncfusion.Pdf.Net.Core to 31.2.18
+- `practices-ui-ktbe` Added `whitespace-pre-line` CSS class to `PuibeReadonlyLabelValueComponent` to properly display line breaks in readonly values.
 
 ### Fixed
 

--- a/ng/practices-ui-ktbe/src/lib/readonly-label-value/readonly-label-value.component.html
+++ b/ng/practices-ui-ktbe/src/lib/readonly-label-value/readonly-label-value.component.html
@@ -2,7 +2,7 @@
     <dt [ngClass]="useSmallLabel ?? useSmallLabelFallback ? 'text-very-small font-normal' : 'text-base font-light'">
         {{ label }}
     </dt>
-    <dd class="text-base font-medium [word-break:break-word]">
+    <dd class="whitespace-pre-line text-base font-medium [word-break:break-word]">
         <ng-content></ng-content>
     </dd>
 </dl>


### PR DESCRIPTION
### Changed

- `practices-ui-ktbe` Added `whitespace-pre-line` CSS class to `PuibeReadonlyLabelValueComponent` to properly display line breaks in readonly values.