### PR TITLE
Fixed form group fluent builder to apply `validators` and `asyncValidators` from control definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Practices.Syncfusion.Excel` Update Syncfusion.XlsIO.Net.Core to 31.2.18
 - `Practices.Syncfusion.Pdf` Update Syncfusion.Pdf.Net.Core to 31.2.18
 - `practices-ui-ktbe` Added `whitespace-pre-line` CSS class to `PuibeReadonlyLabelValueComponent` to properly display line breaks in readonly values.
+- `practices-ng-forms` Updated `toFormControlOptions` nonNullable behavior.
+- _BREAKING_ `practices-ng-forms` Removed `AbstractControl` from `FormGroupDefinitionRecord` to limit configuration to supported properties.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `practices-ng-forms` Fixed form group fluent builder to apply `validators` and `asyncValidators` from control definitions.
+
 ## [11.1.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.1.0) - 2025-12-10
 
 ### Added

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/create-form-group-with-reset-from-signal.spec.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/create-form-group-with-reset-from-signal.spec.ts
@@ -1,7 +1,6 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Validators } from '@angular/forms';
-import { firstValueFrom, of } from 'rxjs';
 import { formGroup } from './api';
 import { createFormGroupWithResetFromSignal } from './create-form-group-with-reset-from-signal';
 
@@ -95,34 +94,6 @@ describe('withResetFromSignal', () => {
             TestBed.flushEffects();
 
             expect(fg.value.name).toEqual('Lara Croft');
-        });
-    });
-
-    it('should apply all control option properties', async () => {
-        await TestBed.runInInjectionContext(async () => {
-            const sourceSignal = signal({ name: 'Lara Croft' });
-            const asyncValidator = () => of(null);
-            const fg = formGroup.withResetFromSignal(sourceSignal, {
-                name: {
-                    value: '',
-                    validators: [Validators.required],
-                    asyncValidators: [asyncValidator],
-                    updateOn: 'blur',
-                    nullable: false,
-                },
-            });
-            TestBed.flushEffects();
-
-            const control = fg.controls.name;
-            control.setValue('');
-            control.updateValueAndValidity();
-
-            expect(control.updateOn).toEqual('blur');
-            expect(control.hasError('required')).toEqual(true);
-            expect((control as any).nonNullable).toEqual(true);
-            expect(control.asyncValidator).toBeDefined();
-            const asyncResult = await firstValueFrom((control.asyncValidator as any)(control));
-            expect(asyncResult).toEqual(null);
         });
     });
 });

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.spec.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.spec.ts
@@ -48,7 +48,7 @@ describe('formGroup', () => {
         });
     });
 
-    it('should reset nullable control to initial value', () => {
+    it('should reset non-nullable control to initial value', () => {
         TestBed.runInInjectionContext(() => {
             const formGroup = createExtendedFormGroup({ name: { value: 'initial', nullable: false } });
 
@@ -60,7 +60,7 @@ describe('formGroup', () => {
         });
     });
 
-    it('should reset nullable control to initial value by default', () => {
+    it('should reset non-nullable control to initial value by default', () => {
         TestBed.runInInjectionContext(() => {
             const formGroup = createExtendedFormGroup({ name: { value: 'initial' } });
 

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.spec.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.spec.ts
@@ -1,6 +1,7 @@
 import { computed, effect, isSignal, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Validators } from '@angular/forms';
+import { firstValueFrom, of } from 'rxjs';
 import { createExtendedFormGroup } from './extensions';
 
 describe('formGroup', () => {
@@ -32,6 +33,71 @@ describe('formGroup', () => {
             results.push(formGroup.value.name);
 
             expect(results).toEqual(['', 'Lara Croft', 'Indiana Jones']);
+        });
+    });
+
+    it('should reset nullable control to null', () => {
+        TestBed.runInInjectionContext(() => {
+            const formGroup = createExtendedFormGroup({ name: { value: '', nullable: true } });
+
+            formGroup.controls.name.setValue('Temp');
+            formGroup.reset();
+
+            const name: string | null = formGroup.value.name;
+            expect(name).toEqual(null);
+        });
+    });
+
+    it('should reset nullable control to initial value', () => {
+        TestBed.runInInjectionContext(() => {
+            const formGroup = createExtendedFormGroup({ name: { value: 'initial', nullable: false } });
+
+            formGroup.controls.name.setValue('Temp');
+            formGroup.reset();
+
+            const name: string | null = formGroup.value.name;
+            expect(name).toEqual('initial');
+        });
+    });
+
+    it('should reset nullable control to initial value by default', () => {
+        TestBed.runInInjectionContext(() => {
+            const formGroup = createExtendedFormGroup({ name: { value: 'initial' } });
+
+            formGroup.controls.name.setValue('Temp');
+            formGroup.reset();
+
+            const name: string | null = formGroup.value.name;
+            expect(name).toEqual('initial');
+        });
+    });
+
+    it('should apply all control option properties', async () => {
+        await TestBed.runInInjectionContext(async () => {
+            const asyncValidator = () => of(null);
+            const formGroup = createExtendedFormGroup({
+                name: {
+                    value: '',
+                    validators: [Validators.required],
+                    asyncValidators: [asyncValidator],
+                    updateOn: 'blur',
+                    nullable: false,
+                },
+            });
+
+            const control = formGroup.controls.name;
+            control.setValue('');
+            control.updateValueAndValidity();
+
+            expect(control.updateOn).toEqual('blur');
+            expect(control.hasError('required')).toEqual(true);
+
+            control.setValue('Temp');
+            formGroup.reset();
+            expect(control.value).toEqual('');
+            expect(control.asyncValidator).toBeDefined();
+            const asyncResult = await firstValueFrom((control.asyncValidator as any)(control));
+            expect(asyncResult).toEqual(null);
         });
     });
 

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
@@ -41,9 +41,7 @@ function toFormControlOptions<T>(
     controlDef: FormControlDefinition<T> | FormControlDefinitionValueOmitted
 ): FormControlOptions {
     return {
-        validators: [],
-        asyncValidators: [],
-        updateOn: controlDef.updateOn,
+        ...controlDef,
     };
 }
 

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
@@ -41,8 +41,8 @@ function toFormControlOptions<T>(
     controlDef: FormControlDefinition<T> | FormControlDefinitionValueOmitted
 ): FormControlOptions {
     return {
-        validators: [],
-        asyncValidators: [],
+        validators: controlDef.validators,
+        asyncValidators: controlDef.asyncValidators,
         updateOn: controlDef.updateOn,
         nonNullable: !controlDef.nullable,
     };

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
@@ -41,7 +41,10 @@ function toFormControlOptions<T>(
     controlDef: FormControlDefinition<T> | FormControlDefinitionValueOmitted
 ): FormControlOptions {
     return {
-        ...controlDef,
+        validators: [],
+        asyncValidators: [],
+        updateOn: controlDef.updateOn,
+        nonNullable: !controlDef.nullable,
     };
 }
 

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/types.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/types.ts
@@ -1,5 +1,12 @@
 import { Injector, Signal } from '@angular/core';
-import { AbstractControl, FormBuilder, FormControlStatus, FormGroup } from '@angular/forms';
+import {
+    AbstractControl,
+    AsyncValidatorFn,
+    FormBuilder,
+    FormControlStatus,
+    FormGroup,
+    ValidatorFn,
+} from '@angular/forms';
 import { FormGroupControlsValues, FormValueSignalsRecordWithoutPostfix, PartialNullable } from '../utils/form.types';
 import { Extensions } from './extensions';
 import { FormGroupValueWithSignals } from './form-group-types';
@@ -21,7 +28,7 @@ export type FormGroupEnhancedWithSignals<TControls = any> = TControls extends {
            * Please use `formGroup.valueSignal` instead to access signals for individual controls.
            */
           readonly value: FormGroupValueWithSignals<TControls>;
-          
+
           /**
            * A signal of the most up-to-date value of the form group.
            *
@@ -79,6 +86,10 @@ export type FormControlDefinition<T> = {
     updateOn?: 'change' | 'blur' | 'submit';
 
     nullable?: boolean;
+
+    validators?: ValidatorFn[];
+
+    asyncValidators?: AsyncValidatorFn[];
 };
 
 export type FormControlDefinitionValueOmitted = {
@@ -90,6 +101,10 @@ export type FormControlDefinitionValueOmitted = {
     updateOn?: 'change' | 'blur' | 'submit';
 
     nullable?: boolean;
+
+    validators?: ValidatorFn[];
+
+    asyncValidators?: AsyncValidatorFn[];
 };
 
 export type FormGroupDefinitionRecord<TValue extends FormGroupValueBase> = {
@@ -197,4 +212,3 @@ export type ValueSatisfying<
     : TValueOrDef extends PartialNullable<TSatisfy>
     ? ValueSatisfyingType<TSatisfy, TValueOrDef>
     : never;
-

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/types.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/types.ts
@@ -133,12 +133,12 @@ type AddNullableIfConfigured<TControlDef, TFallback = TControlDef> = TControlDef
     nullable: true;
 }
     ? TValue | null
+    : TControlDef extends FormControlDefinition<infer TValue>
+    ? TValue
     : TControlDef extends FormControlDefinitionValueOmitted & { nullable: true }
     ? TFallback | null
     : TControlDef extends FormControlDefinitionValueOmitted & { nullable: false }
     ? TFallback
-    : TControlDef extends FormControlDefinition<infer TValue>
-    ? TValue
     : TControlDef extends AbstractControl<infer TValue>
     ? TValue
     : Exclude<TControlDef, FormControlDefinitionValueOmitted>;

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/types.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/types.ts
@@ -85,6 +85,12 @@ export type FormControlDefinition<T> = {
      */
     updateOn?: 'change' | 'blur' | 'submit';
 
+    /**
+     * Whether the form control should allow `null` values and use `null` as its default value.
+     * When `true`, the control can be reset to `null` and its type includes `null` (e.g., `string | null`).
+     * When `false` (default), the control will revert to its initial value when reset and has a non-nullable type.
+     * This maps to Angular's `nonNullable` FormControl option (inverted).
+     */
     nullable?: boolean;
 
     validators?: ValidatorFn[];
@@ -100,6 +106,12 @@ export type FormControlDefinitionValueOmitted = {
      */
     updateOn?: 'change' | 'blur' | 'submit';
 
+    /**
+     * Whether the form control should allow `null` values and use `null` as its default value.
+     * When `true`, the control can be reset to `null` and its type includes `null` (e.g., `string | null`).
+     * When `false` (default), the control will revert to its initial value when reset and has a non-nullable type.
+     * This maps to Angular's `nonNullable` FormControl option (inverted).
+     */
     nullable?: boolean;
 
     validators?: ValidatorFn[];
@@ -108,10 +120,7 @@ export type FormControlDefinitionValueOmitted = {
 };
 
 export type FormGroupDefinitionRecord<TValue extends FormGroupValueBase> = {
-    [K in keyof TValue]:
-        | AbstractControl<TValue[K]>
-        | FormControlDefinition<TValue[K]>
-        | FormControlDefinitionValueOmitted;
+    [K in keyof TValue]: FormControlDefinition<TValue[K]> | FormControlDefinitionValueOmitted;
 };
 
 export type BuildFromGroupValueFn<TValue extends FormGroupValueBase> = (


### PR DESCRIPTION
### Fixed

- `practices-ng-forms` Fixed form group fluent builder to apply `validators` and `asyncValidators` from control definitions.