### PR TITLE
Add button for new table column functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues. 
+
 ### Fixed
+
 
 ## [11.2.1](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.1) - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
+
+### Changed
+
+### Fixed
+
 ## [11.2.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.0) - 2026-04-13
 
 ### Added
@@ -14,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Practices.*` Updated Microsoft.Extensions.* dependencies
+- `Practices.*` Updated Microsoft.Extensions.\* dependencies
 - `Practices.Core` Updated Autofac to 9.1.0
-- `Practices.EntityFramework` Updated Microsoft.EntityFrameworkCore.*
+- `Practices.EntityFramework` Updated Microsoft.EntityFrameworkCore.\*
 - `Practices.Mail` Updated MailKit to 4.15.1
 - `Practices.Syncfusion.Excel` Updated Syncfusion.XlsIO.Net.Core to 31.2.18
 - `Practices.Syncfusion.Pdf` Updated Syncfusion.Pdf.Net.Core to 31.2.18

--- a/ng/practices-ui-ktbe/package.json
+++ b/ng/practices-ui-ktbe/package.json
@@ -2,7 +2,6 @@
     "name": "@nexplore/practices-ui-ktbe",
     "version": "0.0.0-VERSION",
     "peerDependencies": {
-        "@nexplore/practices-ng-signals":"0.0.0-VERSION",
         "@angular/animations": ">=18.0.0 <22.0.0",
         "@angular/cdk": ">=18.0.0 <22.0.0",
         "@angular/common": ">=18.0.0 <22.0.0",
@@ -14,6 +13,7 @@
         "@nexplore/practices-ng-forms": "0.0.0-VERSION",
         "@nexplore/practices-ng-list-view-source": "0.0.0-VERSION",
         "@nexplore/practices-ng-logging": "0.0.0-VERSION",
+        "@nexplore/practices-ng-signals":"0.0.0-VERSION",
         "@nexplore/practices-ng-status": "0.0.0-VERSION",
         "@nexplore/practices-ui": "0.0.0-VERSION",
         "@ng-select/ng-select": ">=13.0.0 <22.0.0",

--- a/ng/practices-ui-ktbe/package.json
+++ b/ng/practices-ui-ktbe/package.json
@@ -3,7 +3,6 @@
     "version": "0.0.0-VERSION",
     "peerDependencies": {
         "@nexplore/practices-ng-signals":"0.0.0-VERSION",
-        "@nx/dependency-checks":"0.0.0-VERSION",
         "@angular/animations": ">=18.0.0 <22.0.0",
         "@angular/cdk": ">=18.0.0 <22.0.0",
         "@angular/common": ">=18.0.0 <22.0.0",

--- a/ng/practices-ui-ktbe/package.json
+++ b/ng/practices-ui-ktbe/package.json
@@ -2,6 +2,8 @@
     "name": "@nexplore/practices-ui-ktbe",
     "version": "0.0.0-VERSION",
     "peerDependencies": {
+        "@nexplore/practices-ng-signals":"0.0.0-VERSION",
+        "@nx/dependency-checks":"0.0.0-VERSION",
         "@angular/animations": ">=18.0.0 <22.0.0",
         "@angular/cdk": ">=18.0.0 <22.0.0",
         "@angular/common": ">=18.0.0 <22.0.0",

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.html
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.html
@@ -1,4 +1,8 @@
-<div class="grid grid-cols-[auto_1fr] items-center gap-2">
+<div class="grid items-center gap-2" [ngClass]="{
+    'grid-cols-[1fr_auto]': this.align === 'right',
+    'grid-cols-[auto_1fr]': this.align === 'left',
+    'grid-cols-[auto_auto] justify-center': align === 'center'
+}">
     <button
         class="flex w-full items-center justify-items-stretch"
         [ngClass]="{ 

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.html
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.html
@@ -1,40 +1,43 @@
-<button
-    class="flex w-full items-center justify-items-stretch"
-    [ngClass]="{ 
+<div class="grid grid-cols-[auto_1fr] items-center gap-2">
+    <button
+        class="flex w-full items-center justify-items-stretch"
+        [ngClass]="{ 
         'flex-row-reverse': this.align === 'right', 
         'justify-center': this.align === 'center',
         'justify-start': this.align === 'right' || this.align === 'left',
         'cursor-pointer': field.sortable,
      }"
-    [disabled]="!field.sortable"
-    (click)="toggleDir()"
-    [ariaDescription]="clickToSortLabel$ | async"
->
-    <span #contentWrapper>
-        <span #content><ng-content></ng-content></span>
-        <span
-            *ngIf="content.children.length === 0"
-            [ngClass]="{ 
+        [disabled]="!field.sortable"
+        (click)="toggleDir()"
+        [ariaDescription]="clickToSortLabel$ | async"
+    >
+        <span #contentWrapper>
+            <span #content><ng-content></ng-content></span>
+            <span
+                *ngIf="content.children.length === 0"
+                [ngClass]="{ 
                 'text-center': this.align === 'center',
                 'text-right': this.align === 'right',
                 'text-left': this.align === 'left',
             }"
-        >
-            {{ label$ | async }}</span
-        >
-    </span>
-    <div *ngIf="field.sortable" class="relative flex h-5 w-7">
-        <puibe-icon-arrow
-            class="group-hover:bg-sand-hover absolute ml-1 mr-1 flex h-5 w-5 items-center rounded-full p-1 transition-all duration-150 hover:!opacity-100"
-            [ngClass]="
-                field.sortDir != null ? 'opacity-100 group-hover:opacity-100' : 'opacity-0 group-hover:opacity-50'
-            "
-            *ngIf="!(busy$ | async)"
-            [direction]="iconDir$ | async"
-        ></puibe-icon-arrow>
-        <puibe-icon-spinner
-            class="absolute ml-1 mr-1 h-5 w-5 items-center rounded-full p-1 transition-all duration-150 group-hover:flex"
-            *ngIf="field.sortDir != null && (busy$ | async)"
-        ></puibe-icon-spinner>
-    </div>
-</button>
+            >
+                {{ label$ | async }}</span
+            >
+        </span>
+        <div *ngIf="field.sortable" class="relative flex h-5 w-7">
+            <puibe-icon-arrow
+                class="group-hover:bg-sand-hover absolute ml-1 mr-1 flex h-5 w-5 items-center rounded-full p-1 transition-all duration-150 hover:!opacity-100"
+                [ngClass]="
+                    field.sortDir != null ? 'opacity-100 group-hover:opacity-100' : 'opacity-0 group-hover:opacity-50'
+                "
+                *ngIf="!(busy$ | async)"
+                [direction]="iconDir$ | async"
+            ></puibe-icon-arrow>
+            <puibe-icon-spinner
+                class="absolute ml-1 mr-1 h-5 w-5 items-center rounded-full p-1 transition-all duration-150 group-hover:flex"
+                *ngIf="field.sortDir != null && (busy$ | async)"
+            ></puibe-icon-spinner>
+        </div>
+    </button>
+    <ng-content select="[slot='right']" />
+</div>

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.html
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.html
@@ -3,7 +3,7 @@
     'grid-cols-[auto_1fr]': this.align === 'left',
     'grid-cols-[auto_auto] justify-center': align === 'center'
 }">
-    <button
+    <div #button
         class="flex w-full items-center justify-items-stretch"
         [ngClass]="{ 
         'flex-row-reverse': this.align === 'right', 
@@ -11,8 +11,8 @@
         'justify-start': this.align === 'right' || this.align === 'left',
         'cursor-pointer': field.sortable,
      }"
-        [disabled]="!field.sortable"
-        (click)="toggleDir()"
+        [attr.role]="field.sortable ? 'button' : ''"
+        [tabindex]="field.sortable ? '0' : '-1'"
         [ariaDescription]="clickToSortLabel$ | async"
     >
         <span #contentWrapper>
@@ -42,6 +42,6 @@
                 *ngIf="field.sortDir != null && (busy$ | async)"
             ></puibe-icon-spinner>
         </div>
-    </button>
+    </div>
     <ng-content select="[slot='right']" />
 </div>

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
@@ -6,11 +6,13 @@ import {
     ElementRef,
     HostBinding,
     Input,
+    Renderer2,
+    signal,
     ViewChild,
 } from '@angular/core';
 import { DestroyService, OrderDirection } from '@nexplore/practices-ui';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { map, shareReplay, switchMap, takeUntil } from 'rxjs';
+import { map, shareReplay, Subscription, switchMap, takeUntil } from 'rxjs';
 
 import { A11yModule } from '@angular/cdk/a11y';
 import { PuibeIconArrowComponent } from '../../icons/icon-arrow.component';
@@ -25,6 +27,7 @@ import {
     sortDirToIconDir,
     sortDirToLabelKey,
 } from './table-column.util';
+import { subscriptionEffect } from '@nexplore/practices-ng-signals';
 
 @Component({
     standalone: true,
@@ -43,15 +46,19 @@ import {
     providers: [DestroyService],
 })
 export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterViewInit {
+    private readonly _sortableSignal = signal(false);    
+    
+    private _column: TableColumnItem<any>;
+
     @HostBinding('class')
-    className = ClassNames.TABLE_COLUMN;
+    public className = ClassNames.TABLE_COLUMN;
 
     @HostBinding('attr.role')
-    role = 'columnheader';
+    public role = 'columnheader';
 
-    @ViewChild('contentWrapper', { static: false }) content: ElementRef<HTMLElement>;
+    @ViewChild('button', { static: true }) protected button: ElementRef<HTMLElement>;
 
-    private _column: TableColumnItem<any>;
+    @ViewChild('contentWrapper', { static: false }) public content: ElementRef<HTMLElement>;
 
     @Input()
     set field(value: TableColumnItem<any> | string | undefined) {
@@ -81,6 +88,8 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
     @Input()
     set sortable(val: boolean) {
         this._table?.patchColumn(this.field, { sortable: val });
+
+        this._sortableSignal.set(val);
     }
 
     @Input()
@@ -122,10 +131,38 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
         private _table: PuibeTableComponent,
         private _elementRef: ElementRef<HTMLElement>,
         private _translate: TranslateService,
-        private _destroy$: DestroyService
-    ) {}
+        private _destroy$: DestroyService,
+        _renderer: Renderer2
+    ) {
+        subscriptionEffect(() => {
+            const sortable = this._sortableSignal();
+
+            // This is a workaround for accessibility reasons (if a element has a click handler, screen-reader emits "clickable", which we don't want, when its not sortable)
+            if (sortable) {
+                const teardown = new Subscription();
+
+                teardown.add(
+                    _renderer.listen(this.button.nativeElement, 'click', () => {
+                        this.toggleDir();
+                    })
+                );
+
+                teardown.add(
+                    _renderer.listen(this.button.nativeElement, 'keydown', (ev) => {
+                        if (ev.key === 'Enter' || ev.key === '') {
+                            ev.preventDefault();
+                            this.toggleDir();
+                        }
+                    })
+                );
+
+                return teardown;
+            }
+        });
+    }
 
     ngAfterViewInit(): void {
+        // TODO (Api smell): All inputs like align, noPadding, and sortable can technically be set dynamically, but this implementation in init handler does not support it. Refactor to signal based approach.
         setHostClassNames(
             {
                 ['text-center']: this.align === 'center',

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
@@ -7,7 +7,6 @@ import {
     HostBinding,
     Input,
     Renderer2,
-    signal,
     ViewChild,
 } from '@angular/core';
 import { DestroyService, OrderDirection } from '@nexplore/practices-ui';

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { DestroyService, OrderDirection } from '@nexplore/practices-ui';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { debounceTime, map, shareReplay, Subscription, switchMap, takeUntil, tap } from 'rxjs';
+import { BehaviorSubject, combineLatest, map, shareReplay, Subscription, switchMap, takeUntil } from 'rxjs';
 
 import { A11yModule } from '@angular/cdk/a11y';
 import { PuibeIconArrowComponent } from '../../icons/icon-arrow.component';
@@ -46,8 +46,9 @@ import { computedPipe, subscriptionEffect } from '@nexplore/practices-ng-signals
     providers: [DestroyService],
 })
 export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterViewInit {
-    
+
     private _column: TableColumnItem<any>;
+    private readonly _fieldSubject = new BehaviorSubject<TableColumnItem<any> | undefined>(undefined);
 
     @HostBinding('class')
     public className = ClassNames.TABLE_COLUMN;
@@ -65,6 +66,7 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
             this.fieldName = value;
         } else if (typeof value === 'object') {
             this._column = value;
+            this._fieldSubject.next(value);
         }
     }
 
@@ -109,8 +111,8 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
 
     @Input() noPadding = false;
 
-    private _column$ = this._table.columns$.pipe(
-        map((_) => this._table.getColumn(this._column)),
+    private _column$ = combineLatest([this._table.columns$, this._fieldSubject]).pipe(
+        map(([_, field]) => this._table.getColumn(field ?? this._column)),
         shareReplay({ refCount: true, bufferSize: 1 })
     );
 
@@ -131,7 +133,7 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
         private _destroy$: DestroyService,
         _renderer: Renderer2
     ) {
-        const sortableSignal = computedPipe(this._column$, debounceTime(0), map((column) => column?.sortable ?? this.field?.sortable));
+        const sortableSignal = computedPipe(this._column$, map((column) => column?.sortable));
         subscriptionEffect(() => {
             const sortable = sortableSignal();
             // This is a workaround for accessibility reasons (if a element has a click handler, screen-reader emits "clickable", which we don't want, when its not sortable)

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { DestroyService, OrderDirection } from '@nexplore/practices-ui';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { map, shareReplay, Subscription, switchMap, takeUntil } from 'rxjs';
+import { debounceTime, map, shareReplay, Subscription, switchMap, takeUntil, tap } from 'rxjs';
 
 import { A11yModule } from '@angular/cdk/a11y';
 import { PuibeIconArrowComponent } from '../../icons/icon-arrow.component';
@@ -27,7 +27,7 @@ import {
     sortDirToIconDir,
     sortDirToLabelKey,
 } from './table-column.util';
-import { subscriptionEffect } from '@nexplore/practices-ng-signals';
+import { computedPipe, subscriptionEffect } from '@nexplore/practices-ng-signals';
 
 @Component({
     standalone: true,
@@ -46,7 +46,6 @@ import { subscriptionEffect } from '@nexplore/practices-ng-signals';
     providers: [DestroyService],
 })
 export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterViewInit {
-    private readonly _sortableSignal = signal(false);    
     
     private _column: TableColumnItem<any>;
 
@@ -88,8 +87,6 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
     @Input()
     set sortable(val: boolean) {
         this._table?.patchColumn(this.field, { sortable: val });
-
-        this._sortableSignal.set(val);
     }
 
     @Input()
@@ -134,13 +131,12 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
         private _destroy$: DestroyService,
         _renderer: Renderer2
     ) {
+        const sortableSignal = computedPipe(this._column$, debounceTime(0), map((column) => column?.sortable ?? this.field?.sortable));
         subscriptionEffect(() => {
-            const sortable = this._sortableSignal();
-
+            const sortable = sortableSignal();
             // This is a workaround for accessibility reasons (if a element has a click handler, screen-reader emits "clickable", which we don't want, when its not sortable)
             if (sortable) {
                 const teardown = new Subscription();
-
                 teardown.add(
                     _renderer.listen(this.button.nativeElement, 'click', () => {
                         this.toggleDir();

--- a/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/column/table-column.component.ts
@@ -45,9 +45,8 @@ import { computedPipe, subscriptionEffect } from '@nexplore/practices-ng-signals
     providers: [DestroyService],
 })
 export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterViewInit {
-
     private _column: TableColumnItem<any>;
-    private readonly _fieldSubject = new BehaviorSubject<TableColumnItem<any> | undefined>(undefined);
+    private readonly _columnChangeSubject = new BehaviorSubject<TableColumnItem<any> | undefined>(undefined);
 
     @HostBinding('class')
     public className = ClassNames.TABLE_COLUMN;
@@ -65,7 +64,7 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
             this.fieldName = value;
         } else if (typeof value === 'object') {
             this._column = value;
-            this._fieldSubject.next(value);
+            this._columnChangeSubject.next(value);
         }
     }
 
@@ -110,7 +109,7 @@ export class PuibeTableColumnComponent implements TableColumnItem<any>, AfterVie
 
     @Input() noPadding = false;
 
-    private _column$ = combineLatest([this._table.columns$, this._fieldSubject]).pipe(
+    private _column$ = combineLatest([this._table.columns$, this._columnChangeSubject]).pipe(
         map(([_, field]) => this._table.getColumn(field ?? this._column)),
         shareReplay({ refCount: true, bufferSize: 1 })
     );

--- a/ng/practices-ui-ktbe/src/lib/table/table.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/table.component.ts
@@ -184,6 +184,10 @@ export class PuibeTableComponent implements Partial<TableViewSourceConfig<any>> 
     }
 
     getColumn(column: TableColumnItem<any>) {
+        if (!column) {
+            return column ?? {};
+        }
+
         let existingColumn: TableColumnItem<any>;
         if (this.tableViewSource) {
             existingColumn = column.fieldName

--- a/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
@@ -841,7 +841,7 @@ export const ColumnWithButton: Story = {
              <span>H2</span>
              <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
             </puibe-table-column>
-            <puibe-table-column>
+            <puibe-table-column align="right">
              <span>H3</span>
              <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
             </puibe-table-column>

--- a/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
@@ -841,8 +841,12 @@ export const ColumnWithButton: Story = {
              <span>H2</span>
              <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
             </puibe-table-column>
-            <puibe-table-column align="right">
+            <puibe-table-column align="center">
              <span>H3</span>
+             <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
+            </puibe-table-column>
+            <puibe-table-column align="right">
+             <span>H4</span>
              <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
             </puibe-table-column>
         </puibe-table>`,

--- a/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
@@ -849,6 +849,9 @@ export const ColumnWithButton: Story = {
              <span>H4</span>
              <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
             </puibe-table-column>
+            <puibe-table-column align="right">
+             <span>H5</span>
+            </puibe-table-column>
         </puibe-table>`,
     }),
 };

--- a/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/table/table.stories.ts
@@ -23,6 +23,7 @@ import { PuibeTablePaginationInfiniteScrollComponent } from './infinite-scroll/t
 import { PuibeTableCellDirective } from './cell/table-cell.directive';
 import { TranslateModule } from '@ngx-translate/core';
 import { PuibeTableColumnTranslateDirective } from './column/table-column-translate.directive';
+import { PuibeIconSearchComponent } from '../icons/icon-search.component';
 
 type Args = { showOptionsMenu?: boolean };
 
@@ -73,6 +74,7 @@ const meta: Meta<Args> = {
                 PuibeButtonDirective,
                 PuibeTableCellDirective,
                 TranslateModule,
+                PuibeIconSearchComponent,
                 PuibeTableColumnTranslateDirective,
             ],
         }),
@@ -826,6 +828,23 @@ export const Celspan2WithDirectiveTable: Story = {
                 <td puibeTableCell align='right'>B2</td>
                 <td puibeTableCell>B3</td>
             </puibe-table-row>
+        </puibe-table>`,
+    }),
+};
+
+export const ColumnWithButton: Story = {
+    render: (_args) => ({
+        template: `
+        <puibe-table class="w-full">
+            <puibe-table-column [sortable]="true">H1</puibe-table-column>
+            <puibe-table-column [sortable]="true">
+             <span>H2</span>
+             <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
+            </puibe-table-column>
+            <puibe-table-column>
+             <span>H3</span>
+             <button slot="right" size="small" puibeButton><puibe-icon-search size="xs" /></button>
+            </puibe-table-column>
         </puibe-table>`,
     }),
 };

--- a/ng/samples-ktbe/src/app/practices-ui-ktbe-samples/tables/table-example/table-example.component.html
+++ b/ng/samples-ktbe/src/app/practices-ui-ktbe-samples/tables/table-example/table-example.component.html
@@ -35,22 +35,13 @@
 >
     <puibe-table-column
         [field]="itemSource.columns.name"
-        [columnLabel]="'Name'"
-        [sortable]="true"
-        class="w-1/4"
-    ></puibe-table-column>
+        class="w-1/4" />
     <puibe-table-column
         [field]="itemSource.columns.type"
-        [columnLabel]="'Type'"
-        [sortable]="true"
-        class="w-1/4"
-    ></puibe-table-column>
+        class="w-1/4" />
     <puibe-table-column
         [field]="itemSource.columns.active"
-        [columnLabel]="'Active'"
-        [sortable]="true"
-        class="w-1/4"
-    ></puibe-table-column>
+        class="w-1/4" />
 
     <puibe-table-row puibeTableRowActionTrigger *ngFor="let item of itemSource.pageData$ | async">
         <puibe-table-cell>

--- a/ng/samples-ktbe/src/app/practices-ui-ktbe-samples/tables/table-example/table-example.component.ts
+++ b/ng/samples-ktbe/src/app/practices-ui-ktbe-samples/tables/table-example/table-example.component.ts
@@ -76,7 +76,20 @@ export class TableExampleComponent {
         { label: 'Type 3', value: SampleType.Type3 },
     ];
     protected readonly itemSource = tableViewSource.withType<SampleListEntry>().withFilterForm({
-        columns: ['type', 'name', 'active'],
+        columns: {
+            name: {
+                columnLabel: 'Name',
+                sortable: true,
+            },
+            type: {
+                columnLabel: 'Type',
+                sortable: true,
+            },
+            active: {
+                columnLabel: 'Active',
+                sortable: true,
+            },
+        },
         loadFn: (params) =>
             tableSampleLoadFn<SampleListEntry>(params, 250, (i) => ({
                 id: i.toString(),


### PR DESCRIPTION
Fixes #

This fixes an accessibility problem where if you added a button into a table column it would result in nested buttons. 
Now it's possible to add the button via slot next to the sorting button.
