### PR TITLE
Add Subcaption slot for PuibeExpansionPanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
+- `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
 
 ### Changed
 
-- `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues. 
+- `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues.
 
 ### Fixed
-
 
 ## [11.2.1](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.1) - 2026-04-17
 

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -28,7 +28,7 @@
                         <ng-content select="[slot='heading-after']"></ng-content>
                     </div>
                     <p class="mt-1" *ngIf="caption">{{ caption }}</p>
-                    <ng-content select="[slot='subcaption']"></ng-content>
+                    <ng-content select="[slot='caption-after']"></ng-content>
                 </div>
                 <div class="flex items-center gap-4">
                     <ng-content select="[slot='arrow-before']"></ng-content>

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -28,6 +28,7 @@
                         <ng-content select="[slot='heading-after']"></ng-content>
                     </div>
                     <p class="mt-1" *ngIf="caption">{{ caption }}</p>
+                    <ng-content select="[slot='subcaption']"></ng-content>
                 </div>
                 <div class="flex items-center gap-4">
                     <ng-content select="[slot='arrow-before']"></ng-content>


### PR DESCRIPTION
Im Projekt gibt's den neuen Usecase für eine Sub-Caption im ExpansionPanel. 

Design:
<img width="933" height="575" alt="image" src="https://github.com/user-attachments/assets/ae954ab3-cc4b-42db-8dd7-5956d3366777" />
