### PR TITLE
fix Tailwind styling and font asset serving in KTBE Storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `practices-ui-ktbe` Fixed KTBE Storybook styling by correcting Tailwind content paths in `samples-ktbe` and mapping Storybook static assets so font files under `/assets/fonts` are served correctly.
+
 ## [11.2.1](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.1) - 2026-04-17
 
 ### Changed

--- a/ng/practices-ui-ktbe/.storybook/main.ts
+++ b/ng/practices-ui-ktbe/.storybook/main.ts
@@ -4,5 +4,6 @@ import mainRoot from '../../.storybook/main';
 const config: StorybookConfig = {
     ...mainRoot,
     stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+    staticDirs: [...(mainRoot.staticDirs ?? []), { from: '../../samples-ktbe/src/assets', to: '/assets' }],
 };
 export default config;

--- a/ng/samples-ktbe/tailwind.config.js
+++ b/ng/samples-ktbe/tailwind.config.js
@@ -1,8 +1,12 @@
 /** @type {import('tailwindcss').Config} **/
 
+const path = require('path');
 const ktbeTheme = require('../practices-ui-ktbe/tailwind.config.js');
 
 module.exports = {
-    content: ['../practices-ui-ktbe/src/**/*.{html,ts}', './src/**/*.{html,ts}'],
+    content: [
+        path.resolve(__dirname, '../practices-ui-ktbe/src/**/*.{html,ts}'),
+        path.resolve(__dirname, './src/**/*.{html,ts}'),
+    ],
     presets: [ktbeTheme],
 };

--- a/ng/samples-ktbe/tailwind.config.js
+++ b/ng/samples-ktbe/tailwind.config.js
@@ -3,6 +3,6 @@
 const ktbeTheme = require('../practices-ui-ktbe/tailwind.config.js');
 
 module.exports = {
-    content: ['./practices-ui-ktbe/src/**/*.{html,ts}', './samples-ktbe/src/**/*.{html,ts}'],
+    content: ['../practices-ui-ktbe/src/**/*.{html,ts}', './src/**/*.{html,ts}'],
     presets: [ktbeTheme],
 };


### PR DESCRIPTION
## Description

This change fixes broken styling and asset serving in the KTBE Storybook build. The Tailwind content paths for the `samples-ktbe` Storybook were corrected (using `path.resolve`) so that utility classes are generated as expected, and the `samples-ktbe` static assets are now served in Storybook so that `/assets/fonts/*` requests resolve correctly and the previous font 404 errors are eliminated. A corresponding unreleased entry documenting the fix was added to the changelog.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified manually by running the KTBE Storybook and confirming that components render with correct Tailwind styling and that fonts load without the previously observed `/assets/fonts/*` 404 errors. No automated tests were added, as the change only affects Storybook build configuration and static asset serving.

## Integration Instructions

N/A
