### PR TITLE
practices-ui-ktbe: add left-content slot to expansion panel and story example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
-- `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `left-content` slot
+- `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `content-before` slot
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
-- `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `content-before` slot
+- `practices-ui-ktbe` Added support for displaying custom left heading inside `PuibeExpansionPanelComponent` via a `heading-before` slot
+- `practices-ui-ktbe` Added `truncateHeading` input to `PuibeExpansionPanelComponent` to truncate long headings with ellipsis.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
+- `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `left-content` slot
 
 ### Changed
 

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -24,7 +24,7 @@
                 <span class="sr-only">{{ 'Practices.Labels_ExpansionPanel' | translate }}</span>
                 <div class="mr-6 flex items-stretch">
                     <div class="flex items-center self-stretch">
-                        <ng-content select="[slot='left-content']"></ng-content>
+                        <ng-content select="[slot='content-before']"></ng-content>
                     </div>
                     <div class="flex flex-col items-start">
                         <div class="flex items-center gap-4">

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -12,7 +12,7 @@
                     'p-3': compact,
                     'bg-dark-sand aria-expanded:bg-sand hover:bg-sand-hover focus:bg-sand-hover aria-expanded:hover:bg-sand-hover aria-expanded:focus:bg-sand-hover':
                         isSand,
-                    'bg-sand aria-expanded:bg-light-sand hover:bg-sand focus:bg-sand aria-expanded:hover:bg-sand aria-expanded:focus:bg-sand': 
+                    'bg-sand aria-expanded:bg-light-sand hover:bg-sand focus:bg-sand aria-expanded:hover:bg-sand aria-expanded:focus:bg-sand':
                         isLightSand,
                     'hover:bg-very-light-gray focus:bg-very-light-gray aria-expanded:hover:bg-very-light-gray aria-expanded:focus:bg-very-light-gray bg-white aria-expanded:bg-white':
                         isWhite,
@@ -22,13 +22,18 @@
                 (click)="toggle(accordionItem)"
             >
                 <span class="sr-only">{{ 'Practices.Labels_ExpansionPanel' | translate }}</span>
-                <div class="mr-6 flex flex-col items-start">
-                    <div class="flex items-center gap-4">
-                        <p *ngIf="heading" [ngClass]="compact ? 'text-base' : 'text-h4'">{{ heading }}</p>
-                        <ng-content select="[slot='heading-after']"></ng-content>
+                <div class="mr-6 flex items-stretch">
+                    <div class="flex items-center self-stretch">
+                        <ng-content select="[slot='left-content']"></ng-content>
                     </div>
-                    <p class="mt-1" *ngIf="caption">{{ caption }}</p>
-                    <ng-content select="[slot='caption-after']"></ng-content>
+                    <div class="flex flex-col items-start">
+                        <div class="flex items-center gap-4">
+                            <p *ngIf="heading" [ngClass]="compact ? 'text-base' : 'text-h4'">{{ heading }}</p>
+                            <ng-content select="[slot='heading-after']"></ng-content>
+                        </div>
+                        <p class="mt-1" *ngIf="caption">{{ caption }}</p>
+                        <ng-content select="[slot='caption-after']"></ng-content>
+                    </div>
                 </div>
                 <div class="flex items-center gap-4">
                     <ng-content select="[slot='arrow-before']"></ng-content>

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -17,25 +17,38 @@
                     'hover:bg-very-light-gray focus:bg-very-light-gray aria-expanded:hover:bg-very-light-gray aria-expanded:focus:bg-very-light-gray bg-white aria-expanded:bg-white':
                         isWhite,
                     'hover:bg-red-hover focus:bg-red-hover aria-expanded:hover:bg-red-hover aria-expanded:focus:bg-red-hover bg-red text-white':
-                        isRed,
+                        isRed
                 }"
                 (click)="toggle(accordionItem)"
             >
                 <span class="sr-only">{{ 'Practices.Labels_ExpansionPanel' | translate }}</span>
-                <div class="mr-6 flex items-stretch">
-                    <div class="flex items-center self-stretch">
-                        <ng-content select="[slot='content-before']"></ng-content>
+                <div class="mr-6 flex min-w-0 flex-1 items-stretch">
+                    <div class="flex shrink-0 items-center self-stretch">
+                        <ng-content select="[slot='heading-before']"></ng-content>
                     </div>
-                    <div class="flex flex-col items-start">
-                        <div class="flex items-center gap-4">
-                            <p *ngIf="heading" [ngClass]="compact ? 'text-base' : 'text-h4'">{{ heading }}</p>
-                            <ng-content select="[slot='heading-after']"></ng-content>
+                    <div class="flex min-w-0 flex-1 flex-col items-start">
+                        <div class="flex min-w-0 max-w-full items-center gap-4">
+                            <p
+                                #headingText
+                                *ngIf="heading"
+                                class="min-w-0"
+                                [ngClass]="[
+                                    compact ? 'text-base' : 'text-h4',
+                                    truncateHeading ? 'truncate' : 'whitespace-normal'
+                                ]"
+                                [attr.title]="truncateHeading ? heading : null"
+                            >
+                                {{ heading }}
+                            </p>
+
+                            <span #headingAfterInlineHost class="inline-flex shrink-0 items-center"></span>
                         </div>
                         <p class="mt-1" *ngIf="caption">{{ caption }}</p>
                         <ng-content select="[slot='caption-after']"></ng-content>
                     </div>
                 </div>
-                <div class="flex items-center gap-4">
+                <div class="flex shrink-0 items-center gap-4">
+                    <span #headingAfterActionHost class="inline-flex shrink-0 items-center"></span>
                     <ng-content select="[slot='arrow-before']"></ng-content>
                     <puibe-icon-arrow
                         direction="down"
@@ -43,6 +56,13 @@
                         class="rotate-0 transition-all duration-[250ms] ease-in-out group-hover:-rotate-90 group-aria-expanded:-rotate-180 group-aria-expanded:group-hover:-rotate-90"
                     ></puibe-icon-arrow>
                 </div>
+
+                <span
+                    #headingAfterWrapper
+                    class="inline-flex shrink-0 items-center whitespace-nowrap text-current [&_*]:text-current"
+                >
+                    <ng-content select="[slot='heading-after']"></ng-content>
+                </span>
             </button>
         </div>
         <div

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.spec.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.spec.ts
@@ -1,0 +1,116 @@
+import '@angular/compiler';
+import { ChangeDetectorRef, ElementRef } from '@angular/core';
+import { PuibeExpansionPanelComponent } from './expansion-panel.component';
+
+describe('PuibeExpansionPanelComponent', () => {
+    let component: PuibeExpansionPanelComponent;
+    let markForCheck: jest.Mock;
+
+    beforeEach(() => {
+        markForCheck = jest.fn();
+        component = new PuibeExpansionPanelComponent(new ElementRef(document.createElement('div')), {
+            markForCheck,
+        } as unknown as ChangeDetectorRef);
+    });
+
+    it('moves the heading after into the action area and reserves its inline width', () => {
+        const { heading, headingAfterInlineHost, headingAfterActionHost, headingAfterWrapper, setHeadingHeight } =
+            setupHeadingAfterLayout();
+
+        setHeadingHeight(48);
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 42);
+
+        component.headingText = { nativeElement: heading } as ElementRef<HTMLElement>;
+        component.headingAfterWrapper = { nativeElement: headingAfterWrapper } as ElementRef<HTMLElement>;
+        component.headingAfterInlineHost = { nativeElement: headingAfterInlineHost } as ElementRef<HTMLElement>;
+        component.headingAfterActionHost = { nativeElement: headingAfterActionHost } as ElementRef<HTMLElement>;
+
+        jest.spyOn(window, 'getComputedStyle').mockReturnValue({ lineHeight: '24px' } as CSSStyleDeclaration);
+
+        component['updateHeadingAfterPosition']();
+
+        expect(headingAfterActionHost.contains(headingAfterWrapper)).toBe(true);
+        expect(headingAfterInlineHost.style.minWidth).toBe('42px');
+        expect(markForCheck).toHaveBeenCalledTimes(1);
+    });
+
+    it('moves the heading after back inline and clears the reserved width when the heading no longer wraps', () => {
+        const { heading, headingAfterInlineHost, headingAfterActionHost, headingAfterWrapper, setHeadingHeight } =
+            setupHeadingAfterLayout();
+
+        setHeadingHeight(48);
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 42);
+
+        component.headingText = { nativeElement: heading } as ElementRef<HTMLElement>;
+        component.headingAfterWrapper = { nativeElement: headingAfterWrapper } as ElementRef<HTMLElement>;
+        component.headingAfterInlineHost = { nativeElement: headingAfterInlineHost } as ElementRef<HTMLElement>;
+        component.headingAfterActionHost = { nativeElement: headingAfterActionHost } as ElementRef<HTMLElement>;
+
+        jest.spyOn(window, 'getComputedStyle').mockReturnValue({ lineHeight: '24px' } as CSSStyleDeclaration);
+
+        component['updateHeadingAfterPosition']();
+        setHeadingHeight(24);
+
+        component['updateHeadingAfterPosition']();
+
+        expect(headingAfterInlineHost.contains(headingAfterWrapper)).toBe(true);
+        expect(headingAfterInlineHost.style.minWidth).toBe('');
+        expect(markForCheck).toHaveBeenCalledTimes(2);
+    });
+
+    it('updates the reserved inline width when the content changes while still wrapped', () => {
+        const { heading, headingAfterInlineHost, headingAfterActionHost, headingAfterWrapper, setHeadingHeight } =
+            setupHeadingAfterLayout();
+
+        setHeadingHeight(48);
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 42);
+
+        component.headingText = { nativeElement: heading } as ElementRef<HTMLElement>;
+        component.headingAfterWrapper = { nativeElement: headingAfterWrapper } as ElementRef<HTMLElement>;
+        component.headingAfterInlineHost = { nativeElement: headingAfterInlineHost } as ElementRef<HTMLElement>;
+        component.headingAfterActionHost = { nativeElement: headingAfterActionHost } as ElementRef<HTMLElement>;
+
+        jest.spyOn(window, 'getComputedStyle').mockReturnValue({ lineHeight: '24px' } as CSSStyleDeclaration);
+
+        component['updateHeadingAfterPosition']();
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 64);
+
+        component['updateHeadingAfterPosition']();
+
+        expect(headingAfterActionHost.contains(headingAfterWrapper)).toBe(true);
+        expect(headingAfterInlineHost.style.minWidth).toBe('64px');
+        expect(markForCheck).toHaveBeenCalledTimes(1);
+    });
+});
+
+function setupHeadingAfterLayout() {
+    let headingHeight = 24;
+    const heading = document.createElement('p');
+    Object.defineProperty(heading, 'clientHeight', {
+        configurable: true,
+        get: () => headingHeight,
+    });
+
+    const headingAfterInlineHost = document.createElement('span');
+    const headingAfterActionHost = document.createElement('span');
+    const headingAfterWrapper = document.createElement('span');
+
+    headingAfterInlineHost.appendChild(headingAfterWrapper);
+
+    return {
+        heading,
+        headingAfterInlineHost,
+        headingAfterActionHost,
+        headingAfterWrapper,
+        setHeadingHeight(height: number) {
+            headingHeight = height;
+        },
+    };
+}
+
+function setHeadingAfterWrapperWidth(element: HTMLElement, width: number) {
+    Object.defineProperty(element, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ width }),
+    });
+}

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
@@ -22,6 +22,13 @@ let nextUniqueId = 0;
 
 const ANIMATION_DURATION_MS = 225;
 
+type HeadingAfterLayout = {
+    heading: HTMLElement;
+    headingAfterWrapper: HTMLElement;
+    headingAfterInlineHost: HTMLElement;
+    headingAfterActionHost: HTMLElement;
+};
+
 const bodyExpansionAnimation: AnimationTriggerMetadata = trigger('bodyExpansion', [
     state(
         'collapsed',
@@ -205,22 +212,73 @@ export class PuibeExpansionPanelComponent implements OnInit, AfterViewInit, OnCh
     }
 
     private updateHeadingAfterPosition(): void {
-        const heading = this.headingText?.nativeElement;
-        const wrapper = this.headingAfterWrapper?.nativeElement;
-        const inlineHost = this.headingAfterInlineHost?.nativeElement;
-        const actionHost = this.headingAfterActionHost?.nativeElement;
+        const layout = this.getHeadingAfterLayout();
 
-        if (!heading || !wrapper || !inlineHost || !actionHost) {
+        if (!layout) {
             return;
         }
 
-        const lineHeight = parseFloat(getComputedStyle(heading).lineHeight);
-        const isWrapped = heading.clientHeight > lineHeight * 1.5;
-        const shouldMoveToActions = !this.truncateHeading && isWrapped;
-        const target = shouldMoveToActions ? actionHost : inlineHost;
+        const shouldRenderInActionArea = this.shouldRenderHeadingAfterInActionArea(layout.heading);
+        const targetHost = shouldRenderInActionArea ? layout.headingAfterActionHost : layout.headingAfterInlineHost;
 
-        if (wrapper.parentElement !== target) {
-            target.appendChild(wrapper);
+        this.updateInlineHostReservation(
+            layout.headingAfterInlineHost,
+            layout.headingAfterWrapper,
+            shouldRenderInActionArea
+        );
+        this.moveHeadingAfterWrapper(layout.headingAfterWrapper, targetHost);
+    }
+
+    private getHeadingAfterLayout(): HeadingAfterLayout | undefined {
+        const heading = this.headingText?.nativeElement;
+        const headingAfterWrapper = this.headingAfterWrapper?.nativeElement;
+        const headingAfterInlineHost = this.headingAfterInlineHost?.nativeElement;
+        const headingAfterActionHost = this.headingAfterActionHost?.nativeElement;
+
+        if (!heading || !headingAfterWrapper || !headingAfterInlineHost || !headingAfterActionHost) {
+            return undefined;
+        }
+
+        return {
+            heading,
+            headingAfterWrapper,
+            headingAfterInlineHost,
+            headingAfterActionHost,
+        };
+    }
+
+    private shouldRenderHeadingAfterInActionArea(heading: HTMLElement): boolean {
+        if (this.truncateHeading) {
+            return false;
+        }
+
+        // If heading wraps to more than one line (> 1.5× line height),
+        // render the heading-after content in the action area (left to arrow-before).
+        const computedLineHeight = parseFloat(getComputedStyle(heading).lineHeight);
+        return heading.clientHeight > computedLineHeight * 1.5;
+    }
+
+    private updateInlineHostReservation(
+        inlineHost: HTMLElement,
+        headingAfterWrapper: HTMLElement,
+        shouldReserveInlineSpace: boolean
+    ): void {
+        // Reserve inline space for the heading-after wrapper to prevent DOM oscillation:
+        // When moving the wrapper to the action area, we keep the inline area width reserved
+        // so the heading doesn't reflow and become single-line again, which would cause
+        // the wrapper to move back inline on the next resize, creating a flicker loop.
+        if (shouldReserveInlineSpace) {
+            const wrapperWidth = Math.ceil(headingAfterWrapper.getBoundingClientRect().width);
+            inlineHost.style.minWidth = `${wrapperWidth}px`;
+        } else {
+            inlineHost.style.minWidth = '';
+        }
+    }
+
+    private moveHeadingAfterWrapper(headingAfterWrapper: HTMLElement, targetHost: HTMLElement): void {
+        // Only move if the DOM parent actually changed to avoid unnecessary reflows.
+        if (headingAfterWrapper.parentElement !== targetHost) {
+            targetHost.appendChild(headingAfterWrapper);
             this.cdr.markForCheck();
         }
     }

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
@@ -1,7 +1,19 @@
 import { animate, AnimationTriggerMetadata, state, style, transition, trigger } from '@angular/animations';
 import { CdkAccordionItem, CdkAccordionModule } from '@angular/cdk/accordion';
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, OnInit, ViewChild } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    HostBinding,
+    Input,
+    OnChanges,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { PuibeIconArrowComponent } from '../icons/icon-arrow.component';
 import { isElementVisibleInVerticalScrollView } from '../util/utils';
@@ -38,7 +50,7 @@ const bodyExpansionAnimation: AnimationTriggerMetadata = trigger('bodyExpansion'
     imports: [CdkAccordionModule, PuibeIconArrowComponent, CommonModule, TranslateModule],
     animations: [bodyExpansionAnimation],
 })
-export class PuibeExpansionPanelComponent implements OnInit {
+export class PuibeExpansionPanelComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
     @HostBinding('class')
     className = 'block';
 
@@ -47,6 +59,18 @@ export class PuibeExpansionPanelComponent implements OnInit {
 
     @ViewChild('content', { static: true })
     contentRef: ElementRef<HTMLElement>;
+
+    @ViewChild('headingText')
+    headingText?: ElementRef<HTMLElement>;
+
+    @ViewChild('headingAfterWrapper')
+    headingAfterWrapper?: ElementRef<HTMLElement>;
+
+    @ViewChild('headingAfterInlineHost')
+    headingAfterInlineHost?: ElementRef<HTMLElement>;
+
+    @ViewChild('headingAfterActionHost')
+    headingAfterActionHost?: ElementRef<HTMLElement>;
 
     private _id: string = (nextUniqueId++).toString();
     @Input()
@@ -96,6 +120,12 @@ export class PuibeExpansionPanelComponent implements OnInit {
     @Input()
     enableContentScroll = false;
 
+    /**
+     * If `true`, truncates the heading text with ellipsis when it overflows.
+     */
+    @Input()
+    truncateHeading = false;
+
     get isSand(): boolean {
         return this.variant === 'sand';
     }
@@ -116,10 +146,33 @@ export class PuibeExpansionPanelComponent implements OnInit {
     // `isInitiallyCollapsed` is only true, if `isExpanded` is initially false. As soon `isExpanded` gets changed, `isInitiallyCollapsed` gets reset to false.
     isInitiallyCollapsed?: boolean = undefined;
 
-    constructor(private elRef: ElementRef<HTMLElement>) {}
+    private resizeObserver?: ResizeObserver;
+
+    constructor(private elRef: ElementRef<HTMLElement>, private cdr: ChangeDetectorRef) {}
 
     ngOnInit(): void {
         this.isInitiallyCollapsed = !this.isExpanded;
+    }
+
+    ngAfterViewInit(): void {
+        this.resizeObserver = new ResizeObserver(() => this.updateHeadingAfterPosition());
+
+        queueMicrotask(() => {
+            if (this.headingText?.nativeElement) {
+                this.resizeObserver?.observe(this.headingText.nativeElement);
+            }
+
+            this.resizeObserver?.observe(this.elRef.nativeElement);
+            this.updateHeadingAfterPosition();
+        });
+    }
+
+    ngOnChanges(): void {
+        queueMicrotask(() => this.updateHeadingAfterPosition());
+    }
+
+    ngOnDestroy(): void {
+        this.resizeObserver?.disconnect();
     }
 
     _getExpandedState(): 'expanded' | 'collapsed' {
@@ -149,5 +202,26 @@ export class PuibeExpansionPanelComponent implements OnInit {
         setTimeout(() => {
             this.elRef.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }, timeout);
+    }
+
+    private updateHeadingAfterPosition(): void {
+        const heading = this.headingText?.nativeElement;
+        const wrapper = this.headingAfterWrapper?.nativeElement;
+        const inlineHost = this.headingAfterInlineHost?.nativeElement;
+        const actionHost = this.headingAfterActionHost?.nativeElement;
+
+        if (!heading || !wrapper || !inlineHost || !actionHost) {
+            return;
+        }
+
+        const lineHeight = parseFloat(getComputedStyle(heading).lineHeight);
+        const isWrapped = heading.clientHeight > lineHeight * 1.5;
+        const shouldMoveToActions = !this.truncateHeading && isWrapped;
+        const target = shouldMoveToActions ? actionHost : inlineHost;
+
+        if (wrapper.parentElement !== target) {
+            target.appendChild(wrapper);
+            this.cdr.markForCheck();
+        }
     }
 }

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -53,7 +53,7 @@ const meta: Meta<Args> = {
             ...args,
         },
         template: `
-        <puibe-expansion-panel class="w-3/4" [heading]="heading" [disableScrollIntoView]="disableScrollIntoView" [enableContentScroll]="enableContentScroll" [headingLevel]="headingLevel" [caption]="caption" [isExpanded]="isExpanded" [variant]="variant" [addItemPadding]="addItemPadding" [truncateHeading]="truncateHeading" [caption]="caption">
+        <puibe-expansion-panel class="w-3/4" [heading]="heading" [disableScrollIntoView]="disableScrollIntoView" [enableContentScroll]="enableContentScroll" [headingLevel]="headingLevel" [caption]="caption" [isExpanded]="isExpanded" [variant]="variant" [addItemPadding]="addItemPadding" [truncateHeading]="truncateHeading">
             <span>Test Content</span>
             ${
                 args.useHeadingBefore
@@ -71,7 +71,7 @@ const meta: Meta<Args> = {
                     ? '<puibe-icon-invalid class="h-6 w-6 block" slot="arrow-before"></puibe-icon-invalid>'
                     : ''
             }
-                </puibe-expansion-panel>`,
+        </puibe-expansion-panel>`,
     }),
 };
 

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -166,7 +166,7 @@ export const ScrollIntoView: Story = {
     }),
 };
 
-export const AccordeonWithLeftContentSlot: Story = {
+export const AccordeonWithContentBeforeSlot: Story = {
     args: {
         heading: 'Invoice-File-Name.pdf',
         isExpanded: false,
@@ -187,7 +187,7 @@ export const AccordeonWithLeftContentSlot: Story = {
             [variant]="variant"
             [addItemPadding]="addItemPadding"
         >
-            <puibe-icon-invalid slot="left-content" size="m" class="mr-4"></puibe-icon-invalid>
+            <puibe-icon-invalid slot="content-before" size="m" class="mr-4"></puibe-icon-invalid>
 
             <span slot="caption-after" class="text-[#e30a17]">Rechnung benötigt Überarbeitung.</span>
 

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -8,13 +8,16 @@ type Args = {
     heading?: string;
     headingLevel?: number;
     caption?: string;
+    useHeadingBefore?: boolean;
     useHeadingAfter?: boolean;
+    useCaptionAfter?: boolean;
     useArrowBefore?: boolean;
     isExpanded?: boolean;
     addItemPadding?: boolean;
     variant?: 'sand' | 'white' | 'red';
     disableScrollIntoView?: boolean;
     enableContentScroll?: boolean;
+    truncateHeading?: boolean;
 };
 
 const meta: Meta<Args> = {
@@ -26,10 +29,14 @@ const meta: Meta<Args> = {
         headingLevel: { type: 'number', defaultValue: 2 },
         useHeadingAfter: { type: 'boolean', defaultValue: false },
         useArrowBefore: { type: 'boolean', defaultValue: false },
+        useHeadingBefore: { type: 'boolean', defaultValue: false },
+        useCaptionAfter: { type: 'boolean', defaultValue: false },
         isExpanded: { type: 'boolean', defaultValue: false },
         addItemPadding: { type: 'boolean', defaultValue: true },
         enableContentScroll: { type: 'boolean', defaultValue: false },
         variant: { type: { name: 'enum', value: ['sand', 'white', 'red'] }, defaultValue: 'sand' },
+        truncateHeading: { type: 'boolean', defaultValue: false },
+        caption: { type: 'string' },
     },
     decorators: [
         moduleMetadata({
@@ -46,19 +53,25 @@ const meta: Meta<Args> = {
             ...args,
         },
         template: `
-        <puibe-expansion-panel class="w-3/4" [heading]="heading" [disableScrollIntoView]="disableScrollIntoView" [enableContentScroll]="enableContentScroll" [headingLevel]="headingLevel" [caption]="caption" [isExpanded]="isExpanded" [variant]="variant" [addItemPadding]="addItemPadding">
+        <puibe-expansion-panel class="w-3/4" [heading]="heading" [disableScrollIntoView]="disableScrollIntoView" [enableContentScroll]="enableContentScroll" [headingLevel]="headingLevel" [caption]="caption" [isExpanded]="isExpanded" [variant]="variant" [addItemPadding]="addItemPadding" [truncateHeading]="truncateHeading" [caption]="caption">
             <span>Test Content</span>
+            ${
+                args.useHeadingBefore
+                    ? '<puibe-icon-invalid slot="heading-before" size="m" class="mr-4"></puibe-icon-invalid>'
+                    : ''
+            }
             ${
                 args.useHeadingAfter
                     ? '<a href="http://www.google.ch" target="_blank" slot="heading-after"><puibe-icon-edit class="w-[1.5em] inline-block translate-y-1"></puibe-icon-edit></a>'
                     : ''
             }
+            ${args.useCaptionAfter ? '<span slot="caption-after">Caption After</span>' : ''}
             ${
                 args.useArrowBefore
                     ? '<puibe-icon-invalid class="h-6 w-6 block" slot="arrow-before"></puibe-icon-invalid>'
                     : ''
             }
-        </puibe-expansion-panel>`,
+                </puibe-expansion-panel>`,
     }),
 };
 
@@ -166,37 +179,73 @@ export const ScrollIntoView: Story = {
     }),
 };
 
-export const AccordeonWithContentBeforeSlot: Story = {
+export const WithAllSlots: Story = {
     args: {
-        heading: 'Invoice-File-Name.pdf',
+        heading: 'Heading',
+        caption: 'A small caption',
+        useHeadingBefore: true,
+        useHeadingAfter: true,
+        useCaptionAfter: true,
+        useArrowBefore: true,
         isExpanded: false,
-        headingLevel: 1,
+        addItemPadding: true,
+        variant: 'white',
+        disableScrollIntoView: false,
+        enableContentScroll: false,
+        truncateHeading: false,
+    },
+};
+
+export const WithAllSlotNamesVisible: Story = {
+    args: {
+        heading: 'Heading',
+        isExpanded: false,
+        headingLevel: 2,
         variant: 'white',
         addItemPadding: false,
+        truncateHeading: false,
+        caption: 'Caption',
     },
     render: (args) => ({
-        props: {
-            ...args,
-        },
+        props: { ...args },
         template: `
-        <puibe-expansion-panel
-            class="w-full max-w-[800px] border border-[#d9d9d9]"
-            [heading]="heading"
-            [headingLevel]="headingLevel"
-            [isExpanded]="isExpanded"
-            [variant]="variant"
-            [addItemPadding]="addItemPadding"
-        >
-            <puibe-icon-invalid slot="content-before" size="m" class="mr-4"></puibe-icon-invalid>
+            <puibe-expansion-panel
+                class="w-full max-w-[800px]"
+                [heading]="heading"
+                [headingLevel]="headingLevel"
+                [isExpanded]="isExpanded"
+                [variant]="variant"
+                [addItemPadding]="addItemPadding"
+                [truncateHeading]="truncateHeading"
+                [caption]="caption"
+            >
+                <span slot="heading-before" class="mr-4">heading-before</span>
+                <span slot="heading-after">heading-after</span>
+                <span slot="caption-after">caption-after</span>
+                <span slot="arrow-before" class="whitespace-nowrap">arrow-before</span>
 
-            <span slot="caption-after" class="text-[#e30a17]">Rechnung benötigt Überarbeitung.</span>
-
-            <span slot="arrow-before" class="inline-flex items-center gap-2 whitespace-nowrap text-black">Entfernen </span>
-
-            <div>
-                Inhalt des Expansion Panels
-            </div>
-        </puibe-expansion-panel>
+                <div>Inhalt des Expansion Panels</div>
+            </puibe-expansion-panel>
         `,
     }),
+};
+
+export const WithLongHeadingWithoutTruncation: Story = {
+    args: {
+        ...WithAllSlots.args,
+        heading:
+            'Invoice-File-Name-This-Is-An-Extremely-Long-Heading-To-Verify-That-The-Expansion-Panel-Title-Can-Wrap-Correctly.pdf',
+        truncateHeading: false,
+    },
+    render: WithAllSlots.render,
+};
+
+export const WithLongHeadingAndTruncation: Story = {
+    args: {
+        ...WithAllSlots.args,
+        heading:
+            'Invoice-File-Name-This-Is-An-Extremely-Long-Heading-To-Verify-That-The-Expansion-Panel-Title-Is-Truncated-Correctly.pdf',
+        truncateHeading: true,
+    },
+    render: WithAllSlots.render,
 };

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -1,8 +1,8 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { PuibeExpansionPanelComponent } from './expansion-panel.component';
 import { PuibeIconEditComponent } from '../icons/icon-edit.component';
 import { PuibeIconInvalidComponent } from '../icons/icon-invalid.component';
+import { PuibeExpansionPanelComponent } from './expansion-panel.component';
 
 type Args = {
     heading?: string;
@@ -162,6 +162,41 @@ export const ScrollIntoView: Story = {
             <h1 class="bg-gray h-96">Test Content 3</h1>
         </puibe-expansion-panel>
         </div>
+        `,
+    }),
+};
+
+export const AccordeonWithLeftContentSlot: Story = {
+    args: {
+        heading: 'Invoice-File-Name.pdf',
+        isExpanded: false,
+        headingLevel: 1,
+        variant: 'white',
+        addItemPadding: false,
+    },
+    render: (args) => ({
+        props: {
+            ...args,
+        },
+        template: `
+        <puibe-expansion-panel
+            class="w-full max-w-[800px] border border-[#d9d9d9]"
+            [heading]="heading"
+            [headingLevel]="headingLevel"
+            [isExpanded]="isExpanded"
+            [variant]="variant"
+            [addItemPadding]="addItemPadding"
+        >
+            <puibe-icon-invalid slot="left-content" size="m" class="mr-4"></puibe-icon-invalid>
+
+            <span slot="caption-after" class="text-[#e30a17]">Rechnung benötigt Überarbeitung.</span>
+
+            <span slot="arrow-before" class="inline-flex items-center gap-2 whitespace-nowrap text-black">Entfernen </span>
+
+            <div>
+                Inhalt des Expansion Panels
+            </div>
+        </puibe-expansion-panel>
         `,
     }),
 };


### PR DESCRIPTION
## Description
Enhances the `practices-ui-ktbe` expansion panel with more flexible header composition:
Added a new `heading-before` slot in the expansion panel header to support custom leading content (for example status icons). Added a new `truncateHeading` input to optionally truncate long heading text with an ellipsis, including a title tooltip that reveals the full text. Refactored the `heading-after` positioning logic into self-documenting methods and added a `minWidth` reservation to prevent DOM oscillation at the wrap boundary. Added Storybook examples demonstrating a header with left content, status caption, and remove-action placement, plus a long-heading truncation scenario.


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Added component unit tests (`expansion-panel.component.spec.ts`) covering the `heading-before` slot, `truncateHeading` behavior, and the wrap/unwrap transitions of `heading-after` positioning with dynamic content.
- Verified the new slots and truncation visually via the added Storybook stories.

## Integration Instructions

N/A — the changes are additive (new optional slot and input) and backwards compatible. Consumers can opt in to the `heading-before` slot and `truncateHeading` input as needed.