### PR TITLE
practices-ui-ktbe: add heading-before slot and truncateHeading input to expansion panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
-- `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `left-content` slot
+- `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `content-before` slot
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
 - `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `content-before` slot
+- `practices-ui-ktbe` Added `truncateHeading` input to `PuibeExpansionPanelComponent` to truncate long headings with ellipsis.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
+- `practices-ui-ktbe` Added support for displaying custom left content inside `PuibeExpansionPanelComponent` via a `left-content` slot
 
 ### Changed
 

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -24,7 +24,7 @@
                 <span class="sr-only">{{ 'Practices.Labels_ExpansionPanel' | translate }}</span>
                 <div class="mr-6 flex items-stretch">
                     <div class="flex items-center self-stretch">
-                        <ng-content select="[slot='left-content']"></ng-content>
+                        <ng-content select="[slot='content-before']"></ng-content>
                     </div>
                     <div class="flex flex-col items-start">
                         <div class="flex items-center gap-4">

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -27,7 +27,7 @@
                         <ng-content select="[slot='content-before']"></ng-content>
                     </div>
                     <div class="flex min-w-0 flex-1 flex-col items-start">
-                        <div class="flex min-w-0 w-full items-center gap-4">
+                        <div class="flex w-full min-w-0 items-center gap-4">
                             <p
                                 *ngIf="heading"
                                 class="min-w-0 flex-1"

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -12,7 +12,7 @@
                     'p-3': compact,
                     'bg-dark-sand aria-expanded:bg-sand hover:bg-sand-hover focus:bg-sand-hover aria-expanded:hover:bg-sand-hover aria-expanded:focus:bg-sand-hover':
                         isSand,
-                    'bg-sand aria-expanded:bg-light-sand hover:bg-sand focus:bg-sand aria-expanded:hover:bg-sand aria-expanded:focus:bg-sand': 
+                    'bg-sand aria-expanded:bg-light-sand hover:bg-sand focus:bg-sand aria-expanded:hover:bg-sand aria-expanded:focus:bg-sand':
                         isLightSand,
                     'hover:bg-very-light-gray focus:bg-very-light-gray aria-expanded:hover:bg-very-light-gray aria-expanded:focus:bg-very-light-gray bg-white aria-expanded:bg-white':
                         isWhite,
@@ -22,13 +22,18 @@
                 (click)="toggle(accordionItem)"
             >
                 <span class="sr-only">{{ 'Practices.Labels_ExpansionPanel' | translate }}</span>
-                <div class="mr-6 flex flex-col items-start">
-                    <div class="flex items-center gap-4">
-                        <p *ngIf="heading" [ngClass]="compact ? 'text-base' : 'text-h4'">{{ heading }}</p>
-                        <ng-content select="[slot='heading-after']"></ng-content>
+                <div class="mr-6 flex items-stretch">
+                    <div class="flex items-center self-stretch">
+                        <ng-content select="[slot='left-content']"></ng-content>
                     </div>
-                    <p class="mt-1" *ngIf="caption">{{ caption }}</p>
-                    <ng-content select="[slot='caption-after']"></ng-content>
+                    <div class="flex flex-col items-start">
+                        <div class="flex items-center gap-4">
+                            <p *ngIf="heading" [ngClass]="compact ? 'text-base' : 'text-h4'">{{ heading }}</p>
+                            <ng-content select="[slot='heading-after']"></ng-content>
+                        </div>
+                        <p class="mt-1" *ngIf="caption">{{ caption }}</p>
+                        <ng-content select="[slot='caption-after']"></ng-content>
+                    </div>
                 </div>
                 <div class="flex items-center gap-4">
                     <ng-content select="[slot='arrow-before']"></ng-content>

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -22,13 +22,20 @@
                 (click)="toggle(accordionItem)"
             >
                 <span class="sr-only">{{ 'Practices.Labels_ExpansionPanel' | translate }}</span>
-                <div class="mr-6 flex items-stretch">
+                <div class="mr-6 flex min-w-0 flex-1 items-stretch">
                     <div class="flex items-center self-stretch">
                         <ng-content select="[slot='content-before']"></ng-content>
                     </div>
-                    <div class="flex flex-col items-start">
-                        <div class="flex items-center gap-4">
-                            <p *ngIf="heading" [ngClass]="compact ? 'text-base' : 'text-h4'">{{ heading }}</p>
+                    <div class="flex min-w-0 flex-1 flex-col items-start">
+                        <div class="flex min-w-0 w-full items-center gap-4">
+                            <p
+                                *ngIf="heading"
+                                class="min-w-0 flex-1"
+                                [ngClass]="[compact ? 'text-base' : 'text-h4', truncateHeading ? 'truncate' : '']"
+                                [attr.title]="truncateHeading ? heading : null"
+                            >
+                                {{ heading }}
+                            </p>
                             <ng-content select="[slot='heading-after']"></ng-content>
                         </div>
                         <p class="mt-1" *ngIf="caption">{{ caption }}</p>

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
@@ -84,6 +84,12 @@ export class PuibeExpansionPanelComponent implements OnInit {
     compact = false;
 
     /**
+     * If `true`, truncates the heading text with ellipsis when it overflows.
+     */
+    @Input()
+    truncateHeading = false;
+
+    /**
      * By default, when expanding a panel, it will automaticly scroll into view. Also, when toggling a already expanded panel which is only barely visible on the screen, it will scroll into view INSTEAD of collapsing.
      * Set to `true` to disable this behavior.
      */

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -166,7 +166,7 @@ export const ScrollIntoView: Story = {
     }),
 };
 
-export const AccordeonWithLeftContentSlot: Story = {
+export const AccordeonWithContentBeforeSlot: Story = {
     args: {
         heading: 'Invoice-File-Name.pdf',
         isExpanded: false,
@@ -187,7 +187,7 @@ export const AccordeonWithLeftContentSlot: Story = {
             [variant]="variant"
             [addItemPadding]="addItemPadding"
         >
-            <puibe-icon-invalid slot="left-content" size="m" class="mr-4"></puibe-icon-invalid>
+            <puibe-icon-invalid slot="content-before" size="m" class="mr-4"></puibe-icon-invalid>
 
             <span slot="caption-after" class="text-[#e30a17]">Rechnung benötigt Überarbeitung.</span>
 

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -200,3 +200,40 @@ export const AccordeonWithContentBeforeSlot: Story = {
         `,
     }),
 };
+
+export const AccordeonWithContentBeforeSlotTruncatedHeading: Story = {
+    args: {
+        heading:
+            'Invoice-File-Name-This-Is-An-Extremely-Long-Heading-To-Verify-That-The-Expansion-Panel-Title-Is-Truncated-Correctly-Even-When-The-Available-Space-Is-Very-Limited-In-The-Header-Area.pdf',
+        isExpanded: false,
+        headingLevel: 1,
+        variant: 'white',
+        addItemPadding: false,
+    },
+    render: (args) => ({
+        props: {
+            ...args,
+        },
+        template: `
+        <puibe-expansion-panel
+            class="w-full max-w-[800px] border border-[#d9d9d9]"
+            [heading]="heading"
+            [headingLevel]="headingLevel"
+            [isExpanded]="isExpanded"
+            [variant]="variant"
+            [addItemPadding]="addItemPadding"
+            [truncateHeading]="true"
+        >
+            <puibe-icon-invalid slot="content-before" size="m" class="mr-4"></puibe-icon-invalid>
+
+            <span slot="caption-after" class="text-[#e30a17]">Rechnung benötigt Überarbeitung.</span>
+
+            <span slot="arrow-before" class="inline-flex items-center gap-2 whitespace-nowrap text-black">Entfernen </span>
+
+            <div>
+                Inhalt des Expansion Panels
+            </div>
+        </puibe-expansion-panel>
+        `,
+    }),
+};

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -1,8 +1,8 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { PuibeExpansionPanelComponent } from './expansion-panel.component';
 import { PuibeIconEditComponent } from '../icons/icon-edit.component';
 import { PuibeIconInvalidComponent } from '../icons/icon-invalid.component';
+import { PuibeExpansionPanelComponent } from './expansion-panel.component';
 
 type Args = {
     heading?: string;
@@ -162,6 +162,41 @@ export const ScrollIntoView: Story = {
             <h1 class="bg-gray h-96">Test Content 3</h1>
         </puibe-expansion-panel>
         </div>
+        `,
+    }),
+};
+
+export const AccordeonWithLeftContentSlot: Story = {
+    args: {
+        heading: 'Invoice-File-Name.pdf',
+        isExpanded: false,
+        headingLevel: 1,
+        variant: 'white',
+        addItemPadding: false,
+    },
+    render: (args) => ({
+        props: {
+            ...args,
+        },
+        template: `
+        <puibe-expansion-panel
+            class="w-full max-w-[800px] border border-[#d9d9d9]"
+            [heading]="heading"
+            [headingLevel]="headingLevel"
+            [isExpanded]="isExpanded"
+            [variant]="variant"
+            [addItemPadding]="addItemPadding"
+        >
+            <puibe-icon-invalid slot="left-content" size="m" class="mr-4"></puibe-icon-invalid>
+
+            <span slot="caption-after" class="text-[#e30a17]">Rechnung benötigt Überarbeitung.</span>
+
+            <span slot="arrow-before" class="inline-flex items-center gap-2 whitespace-nowrap text-black">Entfernen </span>
+
+            <div>
+                Inhalt des Expansion Panels
+            </div>
+        </puibe-expansion-panel>
         `,
     }),
 };


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Added a new `truncateHeading` input to optionally truncate long heading text with ellipsis (including title tooltip for full text).
- Added Storybook examples for a long-heading truncation scenario