### PR TITLE
Introduce async validation in Practices.EntityFramework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
+
 ## [11.3.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.3.0) - 2026-06-24
 
 ### Changed
@@ -16,12 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Practices.Serilog` Updated Serilog.Settings.Configuration to 10.0.1
 - `Practices.Syncfusion.Excel` Updated Syncfusion.XlsIO.Net.Core to 33.2.15
 - `Practices.Syncfusion.Pdf` Updated Syncfusion.Pdf.Net.Core to 33.2.15
-
-### Changed
-
-- `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
-- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
-- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
 
 ## [11.2.2](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.2) - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
+- `Practices.Core` Added TimeProviderClock
+
+### Changed
+
 ### Changed
 
 - `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
+- _BREAKING_ `Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly 
 
 ## [11.3.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.3.0) - 2026-06-24
 
@@ -24,15 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Practices.Serilog` Updated Serilog.Settings.Configuration to 10.0.1
 - `Practices.Syncfusion.Excel` Updated Syncfusion.XlsIO.Net.Core to 33.2.15
 - `Practices.Syncfusion.Pdf` Updated Syncfusion.Pdf.Net.Core to 33.2.15
-
-### Added
-
-- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
-- `Practices.Core` Added TimeProviderClock
-- 
-### Changed
-
--  _BREAKING_`Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
 
 ## [11.2.2](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.2) - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Calling SaveChanges throws NotSupportedException
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
-- _BREAKING_ `Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly 
+- _BREAKING_ `Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
 
 ## [11.3.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.3.0) - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues.
+- `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Calling SaveChanges throws NotSupportedException
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
 - _BREAKING_ `Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-### Changed
-
 - `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues.
-- 
+
 ### Fixed
 
 - `Practices.Syncfusion.Excel` Fixed registration for ExcelEngine (memory leak)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
+
 ## [11.2.2](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.2) - 2026-06-17
 
 ### Added
@@ -17,10 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues.
-- `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
-- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
-- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
-
+- 
 ### Fixed
 
 - `Practices.Syncfusion.Excel` Fixed registration for ExcelEngine (memory leak)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues.
 - `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
 - _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
 
 ### Fixed
 

--- a/dotnet/src/Nexplore.Practices.Core/Domain/Model/IAsyncValidatable.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Domain/Model/IAsyncValidatable.cs
@@ -1,12 +1,10 @@
 namespace Nexplore.Practices.Core.Domain.Model
 {
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using Nexplore.Practices.Core.Validation;
 
-    [SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces", Justification = "Used as marker for all validatable entities, generic and non generic types necessary.")]
     public interface IAsyncValidatable<in TValidationContext> : IValidatable
     {
         Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(TValidationContext context, CancellationToken cancellationToken);

--- a/dotnet/src/Nexplore.Practices.Core/Domain/Model/IAsyncValidatable.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Domain/Model/IAsyncValidatable.cs
@@ -2,13 +2,13 @@ namespace Nexplore.Practices.Core.Domain.Model
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Nexplore.Practices.Core.Validation;
 
     [SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces", Justification = "Used as marker for all validatable entities, generic and non generic types necessary.")]
-    public interface IValidatable;
-
-    public interface IValidatable<in TValidationContext> : IValidatable
+    public interface IAsyncValidatable<in TValidationContext> : IValidatable
     {
-        IEnumerable<EntityValidationError> Validate(TValidationContext context);
+        Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(TValidationContext context, CancellationToken cancellationToken);
     }
 }

--- a/dotnet/src/Nexplore.Practices.Core/Domain/Model/IValidatable.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Domain/Model/IValidatable.cs
@@ -2,15 +2,15 @@ namespace Nexplore.Practices.Core.Domain.Model
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Nexplore.Practices.Core.Validation;
 
     [SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces", Justification = "Used as marker for all validatable entities, generic and non generic types necessary.")]
-    public interface IValidatable
-    {
-    }
+    public interface IValidatable;
 
     public interface IValidatable<in TValidationContext> : IValidatable
     {
-        IEnumerable<EntityValidationError> Validate(TValidationContext context);
+        Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(TValidationContext context, CancellationToken cancellationToken);
     }
 }

--- a/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWork.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWork.cs
@@ -8,8 +8,6 @@ namespace Nexplore.Practices.Core.Scopes
     /// </summary>
     public interface IUnitOfWork : IChildScope
     {
-        void SaveChanges();
-
         Task SaveChangesAsync(CancellationToken cancellationToken = default);
     }
 

--- a/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWorkWithSingleDbTransaction.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWorkWithSingleDbTransaction.cs
@@ -8,8 +8,6 @@ namespace Nexplore.Practices.Core.Scopes
     /// </summary>
     public interface IUnitOfWorkWithSingleDbTransaction : IUnitOfWork
     {
-        void CommitDbTransaction();
-
         Task CommitDbTransactionAsync(CancellationToken cancellationToken = default);
     }
 

--- a/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
@@ -47,6 +47,11 @@ namespace Nexplore.Practices.EntityFramework
             this.modelCreator.OnModelCreating(modelBuilder);
         }
 
+        public override int SaveChanges(bool acceptAllChangesOnSuccess)
+        {
+            throw new NotSupportedException("Synchronous save is not supported anymore, use SaveChangesAsync.");
+        }
+
         public override async Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
         {
             await this.PrepareSaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
@@ -61,13 +61,13 @@ namespace Nexplore.Practices.EntityFramework
             }
         }
 
-        protected virtual Task PrepareSaveChangesAsync(CancellationToken cancellationToken)
+        protected virtual async ValueTask PrepareSaveChangesAsync(CancellationToken cancellationToken)
         {
             this.ChangeTracker.DetectChanges();
 
             this.EnrichMetadata();
 
-            return this.ValidateAsync(detectChangesOnChangeTracker: false, cancellationToken);
+            await this.ValidateAsync(detectChangesOnChangeTracker: false, cancellationToken).ConfigureAwait(false);
         }
 
         protected virtual void EnrichMetadata()
@@ -93,7 +93,7 @@ namespace Nexplore.Practices.EntityFramework
             this.auditHistoryProvider.Value.CreateAuditHistory();
         }
 
-        protected virtual async Task ValidateAsync(bool detectChangesOnChangeTracker, CancellationToken cancellationToken)
+        protected virtual async ValueTask ValidateAsync(bool detectChangesOnChangeTracker, CancellationToken cancellationToken)
         {
             var validationResults = await this.validationProvider.Value.ValidateAsync(detectChangesOnChangeTracker, cancellationToken).ConfigureAwait(false);
             if (validationResults.Count != 0)

--- a/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
@@ -1,7 +1,6 @@
 namespace Nexplore.Practices.EntityFramework
 {
     using System;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
@@ -48,23 +47,9 @@ namespace Nexplore.Practices.EntityFramework
             this.modelCreator.OnModelCreating(modelBuilder);
         }
 
-        public override int SaveChanges(bool acceptAllChangesOnSuccess)
-        {
-            this.PrepareSaveChanges();
-
-            try
-            {
-                return base.SaveChanges(acceptAllChangesOnSuccess);
-            }
-            catch (DbUpdateConcurrencyException)
-            {
-                throw new ConcurrencyException();
-            }
-        }
-
         public override async Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
         {
-            this.PrepareSaveChanges();
+            await this.PrepareSaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
@@ -76,13 +61,13 @@ namespace Nexplore.Practices.EntityFramework
             }
         }
 
-        protected virtual void PrepareSaveChanges()
+        protected virtual Task PrepareSaveChangesAsync(CancellationToken cancellationToken)
         {
             this.ChangeTracker.DetectChanges();
 
             this.EnrichMetadata();
 
-            this.Validate(detectChangesOnChangeTracker: false);
+            return this.ValidateAsync(detectChangesOnChangeTracker: false, cancellationToken);
         }
 
         protected virtual void EnrichMetadata()
@@ -108,10 +93,10 @@ namespace Nexplore.Practices.EntityFramework
             this.auditHistoryProvider.Value.CreateAuditHistory();
         }
 
-        protected virtual void Validate(bool detectChangesOnChangeTracker)
+        protected virtual async Task ValidateAsync(bool detectChangesOnChangeTracker, CancellationToken cancellationToken)
         {
-            var validationResults = this.validationProvider.Value.Validate(detectChangesOnChangeTracker).ToArray();
-            if (validationResults.Length != 0)
+            var validationResults = await this.validationProvider.Value.ValidateAsync(detectChangesOnChangeTracker, cancellationToken).ConfigureAwait(false);
+            if (validationResults.Count != 0)
             {
                 throw new EntityValidationException(validationResults);
             }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWork.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWork.cs
@@ -19,11 +19,6 @@ namespace Nexplore.Practices.EntityFramework.Scopes
             this.lifetimeScope = lifetimeScope;
         }
 
-        public void SaveChanges()
-        {
-            this.context.SaveChanges();
-        }
-
         public Task SaveChangesAsync(CancellationToken cancellationToken)
         {
             return this.context.SaveChangesAsync(cancellationToken);

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWorkWithSingleDbTransaction.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWorkWithSingleDbTransaction.cs
@@ -19,11 +19,6 @@ namespace Nexplore.Practices.EntityFramework.Scopes
             this.transaction = transaction;
         }
 
-        public void CommitDbTransaction()
-        {
-            this.transaction.Commit();
-        }
-
         public async Task CommitDbTransactionAsync(CancellationToken cancellationToken)
         {
             await this.transaction.CommitAsync(cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
@@ -3,6 +3,7 @@ namespace Nexplore.Practices.EntityFramework.Security
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Xml.Linq;
     using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
     using Microsoft.AspNetCore.DataProtection.Repositories;
@@ -40,7 +41,7 @@ namespace Nexplore.Practices.EntityFramework.Security
                 };
 
                 unitOfWork.Dependent.Add(newKey);
-                unitOfWork.SaveChanges();
+                unitOfWork.SaveChangesAsync(CancellationToken.None).GetAwaiter().GetResult(); // No async interface available
             }
         }
 

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
@@ -8,22 +8,31 @@ namespace Nexplore.Practices.EntityFramework.Security
     using Microsoft.AspNetCore.DataProtection.Repositories;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
     using Nexplore.Practices.EntityFramework.Configuration;
 
     public class DataProtectionKeyRepository : IXmlRepository
     {
         private readonly ILogger<DataMisalignedException> logger;
-        private readonly IDbContextFactory dbContextFactory;
+        private readonly IDbContextOptionsProvider contextOptionsProvider;
+        private readonly IDbModelCreator modelCreator;
+        private readonly IOptions<DatabaseOptions> databaseOptions;
 
-        public DataProtectionKeyRepository(ILogger<DataMisalignedException> logger, IDbContextFactory dbContextFactory)
+        public DataProtectionKeyRepository(
+            ILogger<DataMisalignedException> logger,
+            IDbContextOptionsProvider contextOptionsProvider,
+            IDbModelCreator modelCreator,
+            IOptions<DatabaseOptions> databaseOptions)
         {
             this.logger = logger;
-            this.dbContextFactory = dbContextFactory;
+            this.contextOptionsProvider = contextOptionsProvider;
+            this.modelCreator = modelCreator;
+            this.databaseOptions = databaseOptions;
         }
 
         public virtual IReadOnlyCollection<XElement> GetAllElements()
         {
-            using (var dataContext = this.dbContextFactory.Create())
+            using (var dataContext = this.CreateDataProtectionContext())
             {
                 return dataContext.Set<DataProtectionKey>().AsNoTracking().Select(key => TryParseKeyXml(key.Xml, this.logger)).ToList().AsReadOnly();
             }
@@ -31,7 +40,7 @@ namespace Nexplore.Practices.EntityFramework.Security
 
         public virtual void StoreElement(XElement element, string friendlyName)
         {
-            using (var dataContext = this.dbContextFactory.Create())
+            using (var dataContext = this.CreateDataProtectionContext())
             {
                 var newKey = new DataProtectionKey
                 {
@@ -44,6 +53,13 @@ namespace Nexplore.Practices.EntityFramework.Security
             }
         }
 
+        protected virtual DbContext CreateDataProtectionContext()
+        {
+            var context = new DataProtectionDbContext(this.contextOptionsProvider, this.modelCreator);
+            context.ChangeTracker.AutoDetectChangesEnabled = this.databaseOptions.Value.AutoDetectChangesEnabled;
+            return context;
+        }
+
         private static XElement TryParseKeyXml(string xml, ILogger logger)
         {
             try
@@ -54,6 +70,35 @@ namespace Nexplore.Practices.EntityFramework.Security
             {
                 logger?.LogError(exception, "Could not parse xml");
                 return null;
+            }
+        }
+
+        private sealed class DataProtectionDbContext : DbContext, IDataProtectionKeyContext
+        {
+            private readonly IDbContextOptionsProvider contextOptionsProvider;
+            private readonly IDbModelCreator modelCreator;
+
+            public DataProtectionDbContext(IDbContextOptionsProvider contextOptionsProvider, IDbModelCreator modelCreator)
+            {
+                this.contextOptionsProvider = contextOptionsProvider;
+                this.modelCreator = modelCreator;
+            }
+
+            public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                this.contextOptionsProvider.OnConfiguring(optionsBuilder);
+            }
+
+            protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+            {
+                this.modelCreator.ConfigureConventions(configurationBuilder);
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                this.modelCreator.OnModelCreating(modelBuilder);
             }
         }
     }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
@@ -3,36 +3,35 @@ namespace Nexplore.Practices.EntityFramework.Security
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading;
     using System.Xml.Linq;
     using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
     using Microsoft.AspNetCore.DataProtection.Repositories;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
-    using Nexplore.Practices.Core.Scopes;
+    using Nexplore.Practices.EntityFramework.Configuration;
 
     public class DataProtectionKeyRepository : IXmlRepository
     {
         private readonly ILogger<DataMisalignedException> logger;
-        private readonly IUnitOfWorkFactory<DbSet<DataProtectionKey>> unitOfWorkFactory;
+        private readonly IDbContextFactory dbContextFactory;
 
-        public DataProtectionKeyRepository(ILogger<DataMisalignedException> logger, IUnitOfWorkFactory<DbSet<DataProtectionKey>> unitOfWorkFactory)
+        public DataProtectionKeyRepository(ILogger<DataMisalignedException> logger, IDbContextFactory dbContextFactory)
         {
             this.logger = logger;
-            this.unitOfWorkFactory = unitOfWorkFactory;
+            this.dbContextFactory = dbContextFactory;
         }
 
         public virtual IReadOnlyCollection<XElement> GetAllElements()
         {
-            using (var unitOfWork = this.unitOfWorkFactory.Begin())
+            using (var dataContext = this.dbContextFactory.Create())
             {
-                return unitOfWork.Dependent.AsNoTracking().Select(key => TryParseKeyXml(key.Xml, this.logger)).ToList().AsReadOnly();
+                return dataContext.Set<DataProtectionKey>().AsNoTracking().Select(key => TryParseKeyXml(key.Xml, this.logger)).ToList().AsReadOnly();
             }
         }
 
         public virtual void StoreElement(XElement element, string friendlyName)
         {
-            using (var unitOfWork = this.unitOfWorkFactory.Begin())
+            using (var dataContext = this.dbContextFactory.Create())
             {
                 var newKey = new DataProtectionKey
                 {
@@ -40,8 +39,8 @@ namespace Nexplore.Practices.EntityFramework.Security
                     Xml = element.ToString(SaveOptions.DisableFormatting),
                 };
 
-                unitOfWork.Dependent.Add(newKey);
-                unitOfWork.SaveChangesAsync(CancellationToken.None).GetAwaiter().GetResult(); // No async interface available
+                dataContext.Set<DataProtectionKey>().Add(newKey);
+                dataContext.SaveChanges();
             }
         }
 

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/IValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/IValidationProvider.cs
@@ -7,6 +7,6 @@ namespace Nexplore.Practices.EntityFramework.Validation
 
     public interface IValidationProvider
     {
-        Task<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default);
+        ValueTask<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default);
     }
 }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/IValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/IValidationProvider.cs
@@ -1,10 +1,12 @@
 namespace Nexplore.Practices.EntityFramework.Validation
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Nexplore.Practices.Core.Validation;
 
     public interface IValidationProvider
     {
-        IEnumerable<EntityValidationResult> Validate(bool detectChangesOnChangeTracker = true);
+        Task<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default);
     }
 }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
@@ -113,7 +113,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
         {
             var validationErrors = new List<EntityValidationError>();
 
-            if(entity is IValidatable<TValidationContext> syncValidatable)
+            if (entity is IValidatable<TValidationContext> syncValidatable)
             {
                 validationErrors.AddRange(this.ValidateDataAnnotationAttributes(syncValidatable));
             }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
@@ -113,9 +113,11 @@ namespace Nexplore.Practices.EntityFramework.Validation
         {
             var validationErrors = new List<EntityValidationError>();
 
+            validationErrors.AddRange(this.ValidateDataAnnotationAttributes(entity));
+
             if (entity is IValidatable<TValidationContext> syncValidatable)
             {
-                validationErrors.AddRange(this.ValidateDataAnnotationAttributes(syncValidatable));
+                validationErrors.AddRange(syncValidatable.Validate(this.validationContext));
             }
 
             if (entity is IAsyncValidatable<TValidationContext> asyncValidatable)
@@ -126,7 +128,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
             return validationErrors.Count == 0 ? null : new EntityValidationResult(entity, validationErrors);
         }
 
-        private IEnumerable<EntityValidationError> ValidateDataAnnotationAttributes(IValidatable<TValidationContext> entity)
+        private IEnumerable<EntityValidationError> ValidateDataAnnotationAttributes(IValidatable entity)
         {
             var dataAnnotationValidationContext = new ValidationContext(entity);
             var dataAnnotationResults = new Collection<ValidationResult>();

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
@@ -34,7 +34,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
             this.validationLocalizer = stringLocalizerFactory.Create(typeof(ValidationResourceNames));
         }
 
-        public async Task<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default)
+        public async ValueTask<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default)
         {
             if (detectChangesOnChangeTracker)
             {
@@ -93,7 +93,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
             return null;
         }
 
-        private async Task<IReadOnlyCollection<EntityValidationResult>> ValidateMultipleEntitiesAsync(IEnumerable<IValidatable> entities, CancellationToken cancellationToken)
+        private async ValueTask<IReadOnlyCollection<EntityValidationResult>> ValidateMultipleEntitiesAsync(IEnumerable<IValidatable> entities, CancellationToken cancellationToken)
         {
             var result = new List<EntityValidationResult>();
 
@@ -109,7 +109,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
             return result;
         }
 
-        private async Task<EntityValidationResult> ValidateSingleEntityAsync(IValidatable entity, CancellationToken cancellationToken)
+        private async ValueTask<EntityValidationResult> ValidateSingleEntityAsync(IValidatable entity, CancellationToken cancellationToken)
         {
             var validationErrors = new List<EntityValidationError>();
 

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
@@ -6,6 +6,8 @@ namespace Nexplore.Practices.EntityFramework.Validation
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
     using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.ChangeTracking;
     using Microsoft.Extensions.Localization;
@@ -32,7 +34,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
             this.validationLocalizer = stringLocalizerFactory.Create(typeof(ValidationResourceNames));
         }
 
-        public IEnumerable<EntityValidationResult> Validate(bool detectChangesOnChangeTracker = true)
+        public async Task<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default)
         {
             if (detectChangesOnChangeTracker)
             {
@@ -40,7 +42,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
             }
 
             var entriesToValidate = this.changeTracker.Entries<IValidatable<TValidationContext>>().Where(this.IsEntityEntryChanged).ToArray();
-            return this.ValidateMultipleEntities(entriesToValidate.Select(e => e.Entity));
+            return await this.ValidateMultipleEntitiesAsync(entriesToValidate.Select(e => e.Entity), cancellationToken).ConfigureAwait(false);
         }
 
         protected virtual bool IsEntityEntryChanged(EntityEntry<IValidatable<TValidationContext>> entry)
@@ -91,21 +93,29 @@ namespace Nexplore.Practices.EntityFramework.Validation
             return null;
         }
 
-        private IEnumerable<EntityValidationResult> ValidateMultipleEntities(IEnumerable<IValidatable<TValidationContext>> entities)
+        private async Task<IReadOnlyCollection<EntityValidationResult>> ValidateMultipleEntitiesAsync(IEnumerable<IValidatable<TValidationContext>> entities, CancellationToken cancellationToken)
         {
-            return entities.Select(this.ValidateSingleEntity).Where(result => result != null);
-        }
+            var result = new List<EntityValidationResult>();
 
-        private EntityValidationResult ValidateSingleEntity(IValidatable<TValidationContext> entity)
-        {
-            var unitedValidationErrors = this.ValidateDataAnnotationAttributes(entity).Union(this.ValidateValidatable(entity)).ToArray();
-            if (unitedValidationErrors.Length == 0)
+            foreach (var validatable in entities)
             {
-                return null;
+                var validationResult = await this.ValidateSingleEntityAsync(validatable, cancellationToken).ConfigureAwait(false);
+                if (validationResult != null)
+                {
+                    result.Add(validationResult);
+                }
             }
 
-            var validationErrors = new ReadOnlyCollection<EntityValidationError>(unitedValidationErrors);
-            return new EntityValidationResult(entity, validationErrors);
+            return result;
+        }
+
+        private async Task<EntityValidationResult> ValidateSingleEntityAsync(IValidatable<TValidationContext> entity, CancellationToken cancellationToken)
+        {
+            var validationErrors = new List<EntityValidationError>();
+            validationErrors.AddRange(this.ValidateDataAnnotationAttributes(entity));
+            validationErrors.AddRange(await entity.ValidateAsync(this.validationContext, cancellationToken).ConfigureAwait(false));
+
+            return validationErrors.Count == 0 ? null : new EntityValidationResult(entity, validationErrors);
         }
 
         private IEnumerable<EntityValidationError> ValidateDataAnnotationAttributes(IValidatable<TValidationContext> entity)
@@ -124,11 +134,6 @@ namespace Nexplore.Practices.EntityFramework.Validation
 
                 yield return new EntityValidationError(errorMessage, dataAnnotationResult.MemberNames.Single());
             }
-        }
-
-        private IEnumerable<EntityValidationError> ValidateValidatable(IValidatable<TValidationContext> entity)
-        {
-            return entity.Validate(this.validationContext);
         }
     }
 }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
@@ -41,11 +41,11 @@ namespace Nexplore.Practices.EntityFramework.Validation
                 this.changeTracker.DetectChanges();
             }
 
-            var entriesToValidate = this.changeTracker.Entries<IValidatable<TValidationContext>>().Where(this.IsEntityEntryChanged).ToArray();
+            var entriesToValidate = this.changeTracker.Entries<IValidatable>().Where(this.IsEntityEntryChanged).ToArray();
             return await this.ValidateMultipleEntitiesAsync(entriesToValidate.Select(e => e.Entity), cancellationToken).ConfigureAwait(false);
         }
 
-        protected virtual bool IsEntityEntryChanged(EntityEntry<IValidatable<TValidationContext>> entry)
+        protected virtual bool IsEntityEntryChanged(EntityEntry<IValidatable> entry)
         {
             switch (entry.State)
             {
@@ -93,7 +93,7 @@ namespace Nexplore.Practices.EntityFramework.Validation
             return null;
         }
 
-        private async Task<IReadOnlyCollection<EntityValidationResult>> ValidateMultipleEntitiesAsync(IEnumerable<IValidatable<TValidationContext>> entities, CancellationToken cancellationToken)
+        private async Task<IReadOnlyCollection<EntityValidationResult>> ValidateMultipleEntitiesAsync(IEnumerable<IValidatable> entities, CancellationToken cancellationToken)
         {
             var result = new List<EntityValidationResult>();
 
@@ -109,11 +109,19 @@ namespace Nexplore.Practices.EntityFramework.Validation
             return result;
         }
 
-        private async Task<EntityValidationResult> ValidateSingleEntityAsync(IValidatable<TValidationContext> entity, CancellationToken cancellationToken)
+        private async Task<EntityValidationResult> ValidateSingleEntityAsync(IValidatable entity, CancellationToken cancellationToken)
         {
             var validationErrors = new List<EntityValidationError>();
-            validationErrors.AddRange(this.ValidateDataAnnotationAttributes(entity));
-            validationErrors.AddRange(await entity.ValidateAsync(this.validationContext, cancellationToken).ConfigureAwait(false));
+
+            if(entity is IValidatable<TValidationContext> syncValidatable)
+            {
+                validationErrors.AddRange(this.ValidateDataAnnotationAttributes(syncValidatable));
+            }
+
+            if (entity is IAsyncValidatable<TValidationContext> asyncValidatable)
+            {
+                validationErrors.AddRange(await asyncValidatable.ValidateAsync(this.validationContext, cancellationToken).ConfigureAwait(false));
+            }
 
             return validationErrors.Count == 0 ? null : new EntityValidationResult(entity, validationErrors);
         }

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/Bootstrap/Domain/EntityBase.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/Bootstrap/Domain/EntityBase.cs
@@ -2,7 +2,8 @@ namespace Nexplore.Practices.Tests.Integration.Bootstrap.Domain
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Nexplore.Practices.Core.Domain.Model;
     using Nexplore.Practices.Core.Domain.Model.Audit;
     using Nexplore.Practices.Core.Validation;
@@ -10,12 +11,7 @@ namespace Nexplore.Practices.Tests.Integration.Bootstrap.Domain
 
     public abstract class EntityBase : IEntity<Guid>, ITimestamped, IModificationMetadata, IValidatable<IValidationContext>, IAuditable
     {
-        protected EntityBase()
-        {
-            this.Id = Guid.NewGuid();
-        }
-
-        public Guid Id { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
 
         public string CreatedBy { get; set; }
 
@@ -31,9 +27,9 @@ namespace Nexplore.Practices.Tests.Integration.Bootstrap.Domain
 
         public byte[] Timestamp { get; set; }
 
-        public IEnumerable<EntityValidationError> Validate(IValidationContext context)
+        public async Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(IValidationContext context, CancellationToken cancellationToken)
         {
-            return Enumerable.Empty<EntityValidationError>();
+            return await Task.FromResult(Array.Empty<EntityValidationError>());
         }
 
         public string GetAuditKey()

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/Bootstrap/Domain/EntityBase.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/Bootstrap/Domain/EntityBase.cs
@@ -9,7 +9,7 @@ namespace Nexplore.Practices.Tests.Integration.Bootstrap.Domain
     using Nexplore.Practices.Core.Validation;
     using Nexplore.Practices.Tests.Integration.Bootstrap.Validation;
 
-    public abstract class EntityBase : IEntity<Guid>, ITimestamped, IModificationMetadata, IValidatable<IValidationContext>, IAuditable
+    public abstract class EntityBase : IEntity<Guid>, ITimestamped, IModificationMetadata, IValidatable<IValidationContext>, IAsyncValidatable<IValidationContext>, IAuditable
     {
         public Guid Id { get; set; } = Guid.NewGuid();
 
@@ -27,9 +27,14 @@ namespace Nexplore.Practices.Tests.Integration.Bootstrap.Domain
 
         public byte[] Timestamp { get; set; }
 
-        public async Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(IValidationContext context, CancellationToken cancellationToken)
+        public IEnumerable<EntityValidationError> Validate(IValidationContext context)
         {
-            return await Task.FromResult(Array.Empty<EntityValidationError>());
+            yield break;
+        }
+
+        public Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(IValidationContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult((IReadOnlyCollection<EntityValidationError>)[]);
         }
 
         public string GetAuditKey()

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/EntityFramework/UnitOfWorkFactoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/EntityFramework/UnitOfWorkFactoryTests.cs
@@ -42,7 +42,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         {
             // Arrange
             var entityId = Guid.Empty;
-            using (var unitOfWork = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var unitOfWork = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 var entity = unitOfWork.Dependent.Create();
                 entity.FirstName = "Test Firstname";
@@ -70,7 +70,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         {
             // Arrange
             var entityId = Guid.Empty;
-            using (var unitOfWork = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var unitOfWork = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 var entity = unitOfWork.Dependent.Create();
                 entity.FirstName = "Test Firstname";
@@ -100,7 +100,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         [Test]
         public async Task BeginWithSingleDbTransaction_WithChildUnitOfWork_ShareTransaction()
         {
-            using (var superUnit = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var superUnit = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 // Arrange
                 var entityId = Guid.Empty;
@@ -136,8 +136,8 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         public async Task BeginWithSingleDbTransaction_InSeparatedUnitOfWorks_AreIsolatedUntilCommitDbTransaction()
         {
             // Arrange
-            using (var leftUnit = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
-            using (var rightUnit = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var leftUnit = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
+            using (var rightUnit = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 var entity = leftUnit.Dependent.Create();
                 entity.FirstName = "Test Firstname";

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/EntityFramework/UnitOfWorkFactoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/EntityFramework/UnitOfWorkFactoryTests.cs
@@ -80,7 +80,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
 
                 // Act
                 await unitOfWork.SaveChangesAsync();
-                unitOfWork.CommitDbTransaction();
+                await unitOfWork.CommitDbTransactionAsync();
 
                 entityId = entity.Id;
             }
@@ -128,7 +128,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
                     Assert.That(entity.LastName, Is.EqualTo("Test Lastname"));
                 }
 
-                superUnit.CommitDbTransaction();
+                await superUnit.CommitDbTransactionAsync();
             }
         }
 
@@ -155,7 +155,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
                 Assert.That(rightEntityTry, Is.Null);
 
                 // Act
-                leftUnit.CommitDbTransaction();
+                await leftUnit.CommitDbTransactionAsync();
 
                 // Assert
                 var rightEntitySecondTry = await rightUnit.Dependent.GetByIdOrDefaultAsync(entityId);

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
@@ -1,0 +1,89 @@
+namespace Nexplore.Practices.Tests.Unit.EntityFramework.Security
+{
+    using System;
+    using System.Xml.Linq;
+    using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Extensions.Options;
+    using Nexplore.Practices.EntityFramework.Configuration;
+    using Nexplore.Practices.EntityFramework.Security;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DataProtectionKeyRepositoryTests
+    {
+        [Test]
+        public void StoreElement_WithPlainDataProtectionContext_PersistsKeySynchronously()
+        {
+            // Arrange
+            var databaseName = Guid.NewGuid().ToString();
+            var contextOptionsProvider = new InMemoryContextOptionsProvider(databaseName);
+            var modelCreator = new DataProtectionTestModelCreator();
+            var repository = new DataProtectionKeyRepository(
+                NullLogger<DataMisalignedException>.Instance,
+                contextOptionsProvider,
+                modelCreator,
+                Options.Create(new DatabaseOptions()));
+            var element = XElement.Parse("<key id=\"test-key\" />");
+
+            // Act
+            repository.StoreElement(element, "test-friendly-name");
+
+            // Assert
+            using (var dataContext = CreateDataProtectionContext(databaseName))
+            {
+                var key = dataContext.Set<DataProtectionKey>().SingleAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+
+                Assert.That(key.FriendlyName, Is.EqualTo("test-friendly-name"));
+                Assert.That(key.Xml, Is.EqualTo(element.ToString(SaveOptions.DisableFormatting)));
+            }
+        }
+
+        private static TestDataProtectionContext CreateDataProtectionContext(string databaseName)
+        {
+            var options = new DbContextOptionsBuilder<TestDataProtectionContext>()
+                .UseInMemoryDatabase(databaseName)
+                .Options;
+
+            return new TestDataProtectionContext(options);
+        }
+
+        private sealed class InMemoryContextOptionsProvider : IDbContextOptionsProvider
+        {
+            private readonly string databaseName;
+
+            public InMemoryContextOptionsProvider(string databaseName)
+            {
+                this.databaseName = databaseName;
+            }
+
+            public void OnConfiguring(DbContextOptionsBuilder builder)
+            {
+                builder.UseInMemoryDatabase(this.databaseName);
+            }
+        }
+
+        private sealed class DataProtectionTestModelCreator : IDbModelCreator
+        {
+            public void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+            {
+            }
+
+            public void OnModelCreating(ModelBuilder builder)
+            {
+                builder.Entity<DataProtectionKey>();
+            }
+        }
+
+        private sealed class TestDataProtectionContext : DbContext, IDataProtectionKeyContext
+        {
+            public TestDataProtectionContext(DbContextOptions<TestDataProtectionContext> options)
+                : base(options)
+            {
+            }
+
+            public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+        }
+    }
+}

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
@@ -6,14 +6,17 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.15" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.15" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Description

This change introduces asynchronous entity validation to `Nexplore.Practices.EntityFramework` via a new `IAsyncValidatable` interface, allowing entities to perform validation logic that requires awaitable work (such as database lookups) while still honoring existing synchronous `IValidatable` implementations and data annotation checks. As part of aligning the persistence API around async, the synchronous `SaveChanges` overload was removed from `IUnitOfWork` (and the related sync `CommitDbTransaction`), which is a breaking change for callers relying on the sync path; a `NotSupportedException` now guards direct `SaveChanges` usage to prevent bypassing validation. The `DataProtectionKeyRepository` was also refactored to use `IDbContextFactory` so its key persistence works correctly with the async lifecycle.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified through the repository's automated test suite. Unit tests were added for `DataProtectionKeyRepository` covering the `IDbContextFactory`-based persistence, and existing integration tests (`UnitOfWorkFactoryTests`, `EntityBase`) were updated to exercise the new async validation flow.

## Integration Instructions

Consumers must migrate from the removed synchronous `IUnitOfWork.SaveChanges` (and `CommitDbTransaction`) to the async equivalents. Entities requiring awaitable validation should implement the new `IAsyncValidatable` interface. Directly calling EF's `SaveChanges` now throws `NotSupportedException` to avoid circumventing validation.
