### PR TITLE
- introduce TimeProviderClock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
+- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
+- `Practices.Core` Added TimeProviderClock
 
 ### Changed
 
 - `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues.
+-  _BREAKING_`Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
+- `Practices.Core` Added TimeProviderClock
+- 
+### Changed
+
+-  _BREAKING_`Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
+
 ## [11.2.2](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.2) - 2026-06-17
 
 ### Added
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
-- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
-- `Practices.Core` Added TimeProviderClock
 
 ### Changed
 
 - `practices-ui-ktbe` Changed the `PuibeTableColumnComponent` so that it no longer has a button at the root. Instead, there is a div with the role of a button, depending on if the column is sortable. This prevents accessibility issues.
--  _BREAKING_`Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
 
 ### Fixed
 

--- a/dotnet/src/Nexplore.Practices.Core/IClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/IClock.cs
@@ -5,11 +5,12 @@ namespace Nexplore.Practices.Core
     public interface IClock
     {
         DateTime Now { get; }
-
         DateTime UtcNow { get; }
 
-        DateTime Today { get; }
+        DateTimeOffset NowOffset { get; }
+        DateTimeOffset UtcNowOffset { get; }
 
-        DateTime UtcToday { get; }
+        DateOnly Today { get; }
+        DateOnly UtcToday { get; }
     }
 }

--- a/dotnet/src/Nexplore.Practices.Core/LocalComputerClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/LocalComputerClock.cs
@@ -5,11 +5,12 @@ namespace Nexplore.Practices.Core
     public class LocalComputerClock : IClock
     {
         public DateTime Now => DateTime.Now;
-
         public DateTime UtcNow => DateTime.UtcNow;
 
-        public DateTime Today => DateTime.Now.Date;
+        public DateTimeOffset NowOffset => DateTimeOffset.Now;
+        public DateTimeOffset UtcNowOffset => DateTimeOffset.UtcNow;
 
-        public DateTime UtcToday => DateTime.UtcNow.Date;
+        public DateOnly Today => DateOnly.FromDateTime(DateTime.Now);
+        public DateOnly UtcToday => DateOnly.FromDateTime(DateTime.UtcNow);
     }
 }

--- a/dotnet/src/Nexplore.Practices.Core/Registry.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Registry.cs
@@ -1,5 +1,6 @@
 namespace Nexplore.Practices.Core
 {
+    using System;
     using Autofac;
     using Autofac.Core.Lifetime;
     using Nexplore.Practices.Core.Administration;
@@ -12,7 +13,8 @@ namespace Nexplore.Practices.Core
         protected override void Load(ContainerBuilder builder)
         {
             // Configure global services
-            builder.RegisterType<LocalComputerClock>().As<IClock>().SingleInstance();
+            builder.RegisterInstance(TimeProvider.System).As<TimeProvider>().SingleInstance();
+            builder.RegisterType<TimeProviderClock>().As<IClock>().SingleInstance();
             builder.RegisterType<EncryptionService>().As<IEncryptionService>().SingleInstance();
             builder.RegisterType<StaticSaltGenerationService>().As<ISaltGenerationService>().SingleInstance();
             builder.RegisterType<ValidationHelper>().As<IValidationHelper>().SingleInstance();

--- a/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
@@ -1,0 +1,23 @@
+namespace Nexplore.Practices.Core
+{
+    using System;
+
+    public class TimeProviderClock : IClock
+    {
+        private readonly TimeProvider timeProvider;
+
+        public TimeProviderClock(TimeProvider timeProvider)
+        {
+            this.timeProvider = timeProvider;
+        }
+
+        public DateTime Now => this.timeProvider.GetLocalNow().LocalDateTime;
+        public DateTime UtcNow => this.timeProvider.GetUtcNow().UtcDateTime;
+
+        public DateTimeOffset NowOffset => this.timeProvider.GetLocalNow();
+        public DateTimeOffset UtcNowOffset => this.timeProvider.GetLocalNow();
+
+        public DateOnly Today => DateOnly.FromDateTime(this.Now);
+        public DateOnly UtcToday => DateOnly.FromDateTime(this.UtcNow);
+    }
+}

--- a/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
@@ -11,8 +11,8 @@ namespace Nexplore.Practices.Core
             this.timeProvider = timeProvider;
         }
 
-        public DateTime Now => this.timeProvider.GetLocalNow().LocalDateTime;
-        public DateTime UtcNow => this.timeProvider.GetUtcNow().UtcDateTime;
+        public DateTime Now => DateTime.SpecifyKind(this.NowOffset.DateTime, DateTimeKind.Local);
+        public DateTime UtcNow => this.UtcNowOffset.UtcDateTime;
 
         public DateTimeOffset NowOffset => this.timeProvider.GetLocalNow();
         public DateTimeOffset UtcNowOffset => this.timeProvider.GetUtcNow();

--- a/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
@@ -15,7 +15,7 @@ namespace Nexplore.Practices.Core
         public DateTime UtcNow => this.timeProvider.GetUtcNow().UtcDateTime;
 
         public DateTimeOffset NowOffset => this.timeProvider.GetLocalNow();
-        public DateTimeOffset UtcNowOffset => this.timeProvider.GetLocalNow();
+        public DateTimeOffset UtcNowOffset => this.timeProvider.GetUtcNow();
 
         public DateOnly Today => DateOnly.FromDateTime(this.Now);
         public DateOnly UtcToday => DateOnly.FromDateTime(this.UtcNow);

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Generators/DataSeedingService.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Generators/DataSeedingService.cs
@@ -51,7 +51,7 @@ namespace Nexplore.Practices.EntityFramework.Generators
                         }
                     }
 
-                    var now = this.clock.Now;
+                    var now = this.clock.NowOffset;
                     foreach (var migrationToApply in migrationsToApply)
                     {
                         migrationToApply.GeneratorsApplied = now;

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
@@ -94,7 +94,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
             var localTimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/UTC+02", TimeSpan.FromHours(2), "Test/UTC+02", "Test/UTC+02");
             var timeProvider = NSubstitute.Substitute.For<TimeProvider>();
             timeProvider.GetUtcNow().Returns(utcNow);
-            timeProvider.LocalTimeZone.Returns( localTimeZone);
+            timeProvider.LocalTimeZone.Returns(localTimeZone);
             var clock = new TimeProviderClock(timeProvider);
 
             // Act & Assert

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
@@ -2,6 +2,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
 {
     using System;
     using Nexplore.Practices.Core;
+    using NSubstitute;
     using NUnit.Framework;
 
     [TestFixture]
@@ -83,6 +84,29 @@ namespace Nexplore.Practices.Tests.Unit.Core
 
             // Assert
             Assert.That(result.TimeOfDay, Is.Not.EqualTo(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Values_WithCustomLocalTimeZone_AreDerivedFromTimeProvider()
+        {
+            // Arrange
+            var utcNow = new DateTimeOffset(2024, 1, 1, 23, 30, 0, TimeSpan.Zero);
+            var localTimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/UTC+02", TimeSpan.FromHours(2), "Test/UTC+02", "Test/UTC+02");
+            var timeProvider = NSubstitute.Substitute.For<TimeProvider>();
+            timeProvider.GetUtcNow().Returns(utcNow);
+            timeProvider.LocalTimeZone.Returns( localTimeZone);
+            var clock = new TimeProviderClock(timeProvider);
+
+            // Act & Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(clock.UtcNowOffset, Is.EqualTo(utcNow));
+                Assert.That(clock.NowOffset, Is.EqualTo(new DateTimeOffset(2024, 1, 2, 1, 30, 0, TimeSpan.FromHours(2))));
+                Assert.That(clock.UtcNow, Is.EqualTo(new DateTime(2024, 1, 1, 23, 30, 0, DateTimeKind.Utc)));
+                Assert.That(clock.Now, Is.EqualTo(new DateTime(2024, 1, 2, 1, 30, 0, DateTimeKind.Local)));
+                Assert.That(clock.UtcToday, Is.EqualTo(new DateOnly(2024, 1, 1)));
+                Assert.That(clock.Today, Is.EqualTo(new DateOnly(2024, 1, 2)));
+            });
         }
     }
 }

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
@@ -5,13 +5,13 @@ namespace Nexplore.Practices.Tests.Unit.Core
     using NUnit.Framework;
 
     [TestFixture]
-    public class LocalComputerClockTests
+    public class TimeProviderClockTests
     {
         [Test]
         public void Now_WithDefault_IsOfKindLocal()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.Now;
@@ -24,7 +24,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void UtcNow_WithDefault_IsOfKindUtc()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.UtcNow;
@@ -37,7 +37,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void Now_WithDefault_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.Now;
@@ -50,7 +50,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void UtcNow_WithDefault_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.UtcNow;
@@ -63,7 +63,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void NowOffset_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.NowOffset;
@@ -76,7 +76,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void UtcNowOffset_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.UtcNowOffset;


### PR DESCRIPTION
## Description

Introduces a `TimeProviderClock` implementation of `IClock` backed by .NET's `TimeProvider`, and enriches the clock abstraction with `DateTimeOffset` values (`NowOffset`, `UtcNowOffset`). The `Today` and `UtcToday` members change from `DateTime` to the more appropriate `DateOnly` type. This is a breaking change for consumers of `IClock.Today`/`UtcToday`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Added unit tests for `TimeProviderClock` and updated the existing `LocalComputerClock` tests to cover the new `DateOnly` and `DateTimeOffset` members.

## Integration Instructions

Consumers of `IClock.Today` and `IClock.UtcToday` must adapt to the new `DateOnly` return type. The new `TimeProviderClock` can be registered in place of `LocalComputerClock` where a `TimeProvider`-based clock (for example for testability) is desired.