### PR TITLE
Radio-button description as tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
+- `practices-ui-ktbe` Added `PuibeTooltipComponent` for simple display of helper text or context information.
+- `practices-ui-ktbe` Added input on `PuibeRadioButtonComponent` to display `description` as a tooltip.
 
 ### Changed
 

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button-group.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button-group.stories.ts
@@ -9,7 +9,7 @@ type Args = {
     legend: string;
     name?: string;
     hint?: string;
-    values?: { id: number; name: string; description?: string }[];
+    values?: { id: number; name: string; description?: string; descriptionAsTooltip?: boolean }[];
     defaultValue?: string | number;
     required?: boolean;
     disabled?: boolean;
@@ -69,7 +69,7 @@ const meta: Meta<Args> = {
         template: `
         <div [formGroup]="formGroup" class="w-full"  [puibeReadonly]="readonly">
             <puibe-radio-button-group class="w-full" [useSmallTextForReadonlyLabel]="useSmallTextForReadonlyLabel" [legend]="legend" [attr.name]="name" [hint]="hint" formControlName="radio" [displayInline]="displayInline" [hideGroupBorders]="hideGroupBorders" [gapVariant]="gapVariant" [hideOptional]="hideOptional" [legendAsLabel]="legendAsLabel" [readonlyEmptyValuePlaceholder]="readonlyEmptyValuePlaceholder">
-                <puibe-radio-button [value]="value.id" [label]="value.name" [description]="value.description" *ngFor="let value of values; index as i"></puibe-radio-button>
+                <puibe-radio-button [value]="value.id" [label]="value.name" [description]="value.description" [descriptionAsTooltip]="value.descriptionAsTooltip" *ngFor="let value of values; index as i"></puibe-radio-button>
             </puibe-radio-button-group>
         </div>`,
     }),
@@ -272,6 +272,40 @@ export const RadioButtonGroupWithDescription: Story = {
             { id: 1, name: 'Option 1', description: 'Beschreibungstext aus den Stammdaten' },
             { id: 2, name: 'Option 2 mit Zusatz Text', description: 'Beschreibungstext aus den Stammdaten' },
             { id: 3, name: 'Option 3', description: 'Beschreibungstext aus den Stammdaten' },
+        ],
+        defaultValue: null,
+        required: false,
+        disabled: false,
+        displayInline: false,
+        gapVariant: 'large',
+        asyncValidator: false,
+    },
+};
+
+export const RadioButtonGroupWithDescriptionAsTooltip: Story = {
+    args: {
+        legend: 'Label',
+        name: null,
+        hint: null,
+        values: [
+            {
+                id: 1,
+                name: 'Option 1',
+                description: 'Beschreibungstext aus den Stammdaten',
+                descriptionAsTooltip: true,
+            },
+            {
+                id: 2,
+                name: 'Option 2 mit Zusatz Text',
+                description: 'Beschreibungstext aus den Stammdaten. Sehr langer Text, der dann mal umbrechen sollte. ',
+                descriptionAsTooltip: true,
+            },
+            {
+                id: 3,
+                name: 'Option 3',
+                description: 'Beschreibungstext aus den Stammdaten',
+                descriptionAsTooltip: true,
+            },
         ],
         defaultValue: null,
         required: false,

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button-group.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button-group.stories.ts
@@ -9,7 +9,7 @@ type Args = {
     legend: string;
     name?: string;
     hint?: string;
-    values?: { id: number; name: string; description?: string; descriptionAsTooltip?: boolean }[];
+    values?: { id: number; name: string; description?: string }[];
     defaultValue?: string | number;
     required?: boolean;
     disabled?: boolean;
@@ -17,6 +17,7 @@ type Args = {
     hideGroupBorders?: boolean;
     hideOptional?: boolean;
     legendAsLabel?: boolean;
+    descriptionAsTooltip?: boolean;
     gapVariant?: 'default' | 'large';
     asyncValidator?: boolean;
     readonly?: boolean;
@@ -45,6 +46,7 @@ const meta: Meta<Args> = {
         hideGroupBorders: { type: 'boolean', defaultValue: false },
         hideOptional: { type: 'boolean', defaultValue: false },
         legendAsLabel: { type: 'boolean', defaultValue: false },
+        descriptionAsTooltip: { type: 'boolean', defaultValue: false },
         asyncValidator: { type: 'boolean', defaultValue: false },
         readonly: { type: 'boolean', defaultValue: false },
         useSmallTextForReadonlyLabel: { type: 'boolean', defaultValue: false },
@@ -69,7 +71,7 @@ const meta: Meta<Args> = {
         template: `
         <div [formGroup]="formGroup" class="w-full"  [puibeReadonly]="readonly">
             <puibe-radio-button-group class="w-full" [useSmallTextForReadonlyLabel]="useSmallTextForReadonlyLabel" [legend]="legend" [attr.name]="name" [hint]="hint" formControlName="radio" [displayInline]="displayInline" [hideGroupBorders]="hideGroupBorders" [gapVariant]="gapVariant" [hideOptional]="hideOptional" [legendAsLabel]="legendAsLabel" [readonlyEmptyValuePlaceholder]="readonlyEmptyValuePlaceholder">
-                <puibe-radio-button [value]="value.id" [label]="value.name" [description]="value.description" [descriptionAsTooltip]="value.descriptionAsTooltip" *ngFor="let value of values; index as i"></puibe-radio-button>
+                <puibe-radio-button [value]="value.id" [label]="value.name" [description]="value.description" [descriptionAsTooltip]="descriptionAsTooltip" *ngFor="let value of values; index as i"></puibe-radio-button>
             </puibe-radio-button-group>
         </div>`,
     }),
@@ -266,53 +268,18 @@ export const AsyncValidatorRadioButtonGroup: Story = {
 export const RadioButtonGroupWithDescription: Story = {
     args: {
         legend: 'Label',
-        name: null,
-        hint: null,
         values: [
             { id: 1, name: 'Option 1', description: 'Beschreibungstext aus den Stammdaten' },
-            { id: 2, name: 'Option 2 mit Zusatz Text', description: 'Beschreibungstext aus den Stammdaten' },
-            { id: 3, name: 'Option 3', description: 'Beschreibungstext aus den Stammdaten' },
-        ],
-        defaultValue: null,
-        required: false,
-        disabled: false,
-        displayInline: false,
-        gapVariant: 'large',
-        asyncValidator: false,
-    },
-};
-
-export const RadioButtonGroupWithDescriptionAsTooltip: Story = {
-    args: {
-        legend: 'Label',
-        name: null,
-        hint: null,
-        values: [
-            {
-                id: 1,
-                name: 'Option 1',
-                description: 'Beschreibungstext aus den Stammdaten',
-                descriptionAsTooltip: true,
-            },
             {
                 id: 2,
                 name: 'Option 2 mit Zusatz Text',
-                description: 'Beschreibungstext aus den Stammdaten. Sehr langer Text, der dann mal umbrechen sollte. ',
-                descriptionAsTooltip: true,
+                description: 'Beschreibungstext aus den Stammdaten. Sehr langer Text, der dann mal umbrechen sollte.',
             },
-            {
-                id: 3,
-                name: 'Option 3',
-                description: 'Beschreibungstext aus den Stammdaten',
-                descriptionAsTooltip: true,
-            },
+            { id: 3, name: 'Option 3', description: 'Beschreibungstext aus den Stammdaten' },
         ],
-        defaultValue: null,
-        required: false,
-        disabled: false,
         displayInline: false,
+        descriptionAsTooltip: false,
         gapVariant: 'large',
-        asyncValidator: false,
     },
 };
 

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
@@ -38,9 +38,9 @@
         {{ label }}
         @if(description) {
             @if(descriptionAsTooltip) {
-                <puibe-tooltip class="ml-1">
+                <puibe-tooltip-button class="ml-1">
                     <p class="text-small">{{ description }}</p>
-                </puibe-tooltip>
+                </puibe-tooltip-button>
             } @else {
                 <span class="text-very-small block">{{ description }}</span>
             } 

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
@@ -34,8 +34,14 @@
             ></div>
         </div>
     </div>
-    <div class="flex flex-col">
+    <div>
         {{ label }}
-        <span class="text-very-small" *ngIf="description">{{ description }}</span>
+        @if(description) { @if(descriptionAsTooltip) {
+        <puibe-tooltip class="ml-1">
+            <p class="text-small">{{ description }}</p>
+        </puibe-tooltip>
+        } @else {
+        <span class="text-very-small block">{{ description }}</span>
+        } }
     </div>
 </label>

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
@@ -36,12 +36,14 @@
     </div>
     <div>
         {{ label }}
-        @if(description) { @if(descriptionAsTooltip) {
-        <puibe-tooltip class="ml-1">
-            <p class="text-small">{{ description }}</p>
-        </puibe-tooltip>
-        } @else {
-        <span class="text-very-small block">{{ description }}</span>
-        } }
+        @if(description) {
+            @if(descriptionAsTooltip) {
+                <puibe-tooltip class="ml-1">
+                    <p class="text-small">{{ description }}</p>
+                </puibe-tooltip>
+            } @else {
+                <span class="text-very-small block">{{ description }}</span>
+            } 
+        }
     </div>
 </label>

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { PuiFormFieldService } from '@nexplore/practices-ng-forms';
 import { map } from 'rxjs';
+import { PuibeTooltipComponent } from '../tooltip/tooltip.component';
 import { RadioButtonGroupService } from './radio-button-group.service';
 
 let nextUniqueId = 0;
@@ -12,7 +13,7 @@ let nextUniqueId = 0;
     selector: 'puibe-radio-button',
     templateUrl: './radio-button.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgClass, ReactiveFormsModule, AsyncPipe, NgIf],
+    imports: [NgClass, ReactiveFormsModule, AsyncPipe, NgIf, PuibeTooltipComponent],
 })
 export class PuibeRadioButtonComponent {
     @Input()
@@ -23,6 +24,9 @@ export class PuibeRadioButtonComponent {
 
     @Input()
     description: string;
+
+    @Input()
+    descriptionAsTooltip = false;
 
     uniqueId = `radio-button-${nextUniqueId++}`;
 

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { PuiFormFieldService } from '@nexplore/practices-ng-forms';
 import { map } from 'rxjs';
-import { PuibeTooltipComponent } from '../tooltip/tooltip.component';
+import { PuibeTooltipButtonComponent } from '../tooltip/tooltip.component';
 import { RadioButtonGroupService } from './radio-button-group.service';
 
 let nextUniqueId = 0;
@@ -13,7 +13,7 @@ let nextUniqueId = 0;
     selector: 'puibe-radio-button',
     templateUrl: './radio-button.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgClass, ReactiveFormsModule, AsyncPipe, NgIf, PuibeTooltipComponent],
+    imports: [NgClass, ReactiveFormsModule, AsyncPipe, NgIf, PuibeTooltipButtonComponent],
 })
 export class PuibeRadioButtonComponent {
     @Input()

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip-icon.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip-icon.component.ts
@@ -1,0 +1,32 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+    standalone: true,
+    selector: 'puibe-tooltip-icon',
+    template: `<svg
+        [class]="class"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        version="1.1"
+        x="0px"
+        y="0px"
+        width="14px"
+        height="24px"
+        viewBox="0 0 14 24"
+        enable-background="new 0 0 14 24"
+        xml:space="preserve"
+    >
+        <polygon
+            fill="white"
+            stroke="#000000"
+            stroke-width="1"
+            stroke-miterlimit="10"
+            points="0,12 7,0   14,12 7,24 "
+        />
+        <rect x="0" y="0" width="14" height="12" fill="white" />
+    </svg>`,
+})
+export class PuibeTooltipIconComponent {
+    @HostBinding('class') class = '';
+}
+

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
@@ -16,7 +16,7 @@
         [class]="signCssClasses[signpostDirection]"
         aria-live="polite"
     >
-        <div class="border bg-white p-3" [ngClass]="overlayMaxWidthClass()">
+        <div class="border bg-white p-3" [ngClass]="overlayMaxWidthClassSignal()">
             <ng-content></ng-content>
         </div>
 

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
@@ -16,11 +16,10 @@
         [class]="signCssClasses[signpostDirection]"
         aria-live="polite"
     >
-        <div class="border bg-white p-3" [ngClass]="noMaxWidth() ? '' : 'max-w-md'">
+        <div class="border bg-white p-3" [ngClass]="overlayMaxWidthClass()">
             <ng-content></ng-content>
         </div>
 
         <puibe-tooltip-icon [style]="postTranslationCssStyle"></puibe-tooltip-icon>
     </div>
 </ng-template>
-

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
@@ -1,0 +1,26 @@
+<button
+    cdkOverlayOrigin
+    class="text-small leading-ktbe-small select-none rounded-full border bg-white px-[5px] py-0 font-bold transition-all duration-200 ease-in-out hover:scale-[1.2]"
+    (click)="toggle()"
+    [attr.aria-describedby]="tooltipId"
+    [attr.aria-label]="'Shared.ClickForMoreInfo' | translate"
+>
+    ?
+</button>
+
+<ng-template>
+    <div
+        role="tooltip"
+        [id]="tooltipId"
+        class="flex items-center justify-center"
+        [class]="signCssClasses[signpostDirection]"
+        aria-live="polite"
+    >
+        <div class="border bg-white p-3" [ngClass]="noMaxWidth() ? '' : 'max-w-md'">
+            <ng-content></ng-content>
+        </div>
+
+        <puibe-tooltip-icon [style]="postTranslationCssStyle"></puibe-tooltip-icon>
+    </div>
+</ng-template>
+

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
@@ -1,0 +1,227 @@
+import { CdkOverlayOrigin, ConnectedPosition, Overlay, OverlayModule, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { CommonModule, DOCUMENT } from '@angular/common';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    HostBinding,
+    HostListener,
+    OnDestroy,
+    TemplateRef,
+    ViewChild,
+    ViewContainerRef,
+    inject,
+    input,
+} from '@angular/core';
+import { DestroyService } from '@nexplore/practices-ui';
+import { TranslateModule } from '@ngx-translate/core';
+import { takeUntil } from 'rxjs';
+import { PuibeTooltipIconComponent } from './tooltip-icon.component';
+
+type TooltipDirection = 'top' | 'bottom' | 'left' | 'right' | 'auto';
+
+const OVERLAY_POSITIONS: { [K in TooltipDirection]: ConnectedPosition } = {
+    top: {
+        originX: 'center',
+        originY: 'top',
+        overlayX: 'center',
+        overlayY: 'bottom',
+    },
+    bottom: {
+        originX: 'center',
+        originY: 'bottom',
+        overlayX: 'center',
+        overlayY: 'top',
+    },
+    left: {
+        originX: 'start',
+        originY: 'center',
+        overlayX: 'end',
+        overlayY: 'center',
+    },
+    right: {
+        originX: 'end',
+        originY: 'center',
+        overlayX: 'start',
+        overlayY: 'center',
+    },
+    auto: {
+        originX: 'center',
+        originY: 'center',
+        overlayX: 'center',
+        overlayY: 'center',
+    },
+};
+
+const SIGNPOST_SIGN_CSS_CLASSES: { [K in TooltipDirection]: string } = {
+    top: 'flex-col',
+    bottom: 'flex-col-reverse',
+    left: 'flex-row',
+    right: 'flex-row-reverse',
+    auto: 'flex-col',
+};
+
+const SIGNPOST_POST_CSS_STYLES: { [K in TooltipDirection]: string } = {
+    top: ` translateY(-13px)`,
+    bottom: ` translateY(13px) rotate(180deg)`,
+    left: ` translateX(-8px) rotate(270deg)`,
+    right: ` translateX(8px) rotate(90deg)`,
+    auto: 'display: none',
+};
+
+let nextUniqueId = 0;
+
+@Component({
+    selector: 'puibe-tooltip',
+    imports: [CommonModule, OverlayModule, TranslateModule, PuibeTooltipIconComponent],
+    providers: [DestroyService],
+    templateUrl: './tooltip.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PuibeTooltipComponent implements AfterViewInit, OnDestroy {
+    private readonly document = inject<Document>(DOCUMENT);
+    readonly overlayService = inject(Overlay);
+    private readonly destroy$ = inject(DestroyService);
+    readonly viewContainerRef = inject(ViewContainerRef);
+    private readonly cdr = inject(ChangeDetectorRef);
+
+    @ViewChild(CdkOverlayOrigin) private readonly origin: CdkOverlayOrigin | undefined;
+    @ViewChild(TemplateRef) private readonly signpostRef: TemplateRef<HTMLDivElement> | undefined;
+
+    public readonly signCssClasses: { [K in TooltipDirection]: string } = SIGNPOST_SIGN_CSS_CLASSES;
+    public readonly tooltipId = `tooltip-${nextUniqueId++}`;
+    public signpostDirection: TooltipDirection = 'top';
+    public postTranslationCssStyle = '';
+
+    private overlayRef: OverlayRef | undefined;
+    private templatePortal: TemplatePortal<HTMLDivElement> | undefined;
+    private overlayObserver: MutationObserver | undefined;
+
+    @HostBinding('class') protected hostClass = 'inline';
+    @HostListener('document:keydown.escape') onKeydownHandler() {
+        this.overlayRef?.detach();
+    }
+
+    public readonly noMaxWidth = input(false);
+
+    public toggle() {
+        if (this.overlayRef?.hasAttached()) {
+            this.overlayRef?.detach();
+            return;
+        }
+        this.overlayRef?.attach(this.templatePortal);
+    }
+
+    public ngAfterViewInit(): void {
+        if (!this.signpostRef) {
+            return;
+        }
+
+        this.templatePortal = new TemplatePortal(this.signpostRef, this.viewContainerRef);
+
+        const scrollStrategy = this.overlayService.scrollStrategies.close();
+
+        const overlayConfig = {
+            hasBackdrop: true,
+            backdropClass: 'cdk-overlay-transparent-backdrop',
+            scrollStrategy,
+        };
+
+        this.overlayRef = this.overlayService.create(overlayConfig);
+
+        this.overlayRef
+            .backdropClick()
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(() => this.overlayRef?.detach());
+
+        this.overlayObserver = new MutationObserver(() => this.setOverlayDirection());
+        this.overlayObserver.observe(this.overlayRef.overlayElement, {
+            attributes: false,
+            childList: true,
+            subtree: false,
+        });
+    }
+
+    public ngOnDestroy(): void {
+        this.overlayRef?.dispose();
+        this.overlayObserver?.disconnect();
+    }
+
+    private setOverlayDirection() {
+        if (!this.origin || !this.overlayRef) {
+            return;
+        }
+        if (!this.overlayRef.hasAttached()) {
+            return;
+        }
+
+        this.findOverlayDirection(this.origin, this.overlayRef);
+
+        const positionStrategy = this.overlayService
+            .position()
+            .flexibleConnectedTo(this.origin.elementRef)
+            .withFlexibleDimensions(true)
+            .withPush(true)
+            .withGrowAfterOpen(true)
+            .withPositions([OVERLAY_POSITIONS[this.signpostDirection]]);
+
+        this.overlayRef.updatePositionStrategy(positionStrategy);
+        this.overlayRef.updatePosition();
+
+        this.setPostOffset(this.origin, this.overlayRef);
+
+        this.cdr.detectChanges();
+    }
+
+    private findOverlayDirection(origin: CdkOverlayOrigin, overlayRef: OverlayRef) {
+        const defaultWindow = this.document.defaultView;
+        if (defaultWindow) {
+            // Determine the direction of the signpost, based on the space around the origin and the size of the overlay
+            const { top, left, width, height } = origin.elementRef.nativeElement.getBoundingClientRect();
+            const { width: overlayWidth, height: overlayHeight } = overlayRef.overlayElement.getBoundingClientRect();
+            const spaceTop = top;
+            const spaceLeft = left;
+            const spaceRight = defaultWindow.innerWidth - (spaceLeft + width);
+            const spaceBottom = defaultWindow.innerHeight - (spaceTop + height);
+
+            const solutions: { [K in TooltipDirection]: boolean } = {
+                top: spaceTop >= overlayHeight,
+                bottom: spaceBottom >= overlayHeight,
+                left: spaceLeft >= overlayWidth,
+                right: spaceRight >= overlayWidth,
+                auto: true,
+            };
+
+            this.signpostDirection = Object.entries(solutions).filter(
+                (entry) => entry[1] === true
+            )[0][0] as TooltipDirection;
+        }
+    }
+
+    private setPostOffset(origin: CdkOverlayOrigin, overlayRef: OverlayRef) {
+        const { top, left, width, height } = origin.elementRef.nativeElement.getBoundingClientRect();
+        const {
+            width: overlayWidth,
+            height: overlayHeight,
+            top: overlayTop,
+            left: overlayLeft,
+        } = overlayRef.overlayElement.getBoundingClientRect();
+
+        const horizontalCenter = left + width / 2;
+        const verticalCenter = top + height / 2;
+        const overlayHorizontalCenter = overlayLeft + overlayWidth / 2;
+        const overlayVerticalCenter = overlayTop + overlayHeight / 2;
+
+        this.postTranslationCssStyle =
+            {
+                top: `transform: translateX(${horizontalCenter - overlayHorizontalCenter}px)`,
+                bottom: `transform: translateX(${horizontalCenter - overlayHorizontalCenter}px)`,
+                left: `transform: translateY(${verticalCenter - overlayVerticalCenter}px)`,
+                right: `transform: translateY(${verticalCenter - overlayVerticalCenter}px)`,
+                auto: '',
+            }[this.signpostDirection] + SIGNPOST_POST_CSS_STYLES[this.signpostDirection];
+    }
+}
+

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
@@ -6,14 +6,13 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    HostBinding,
     HostListener,
     OnDestroy,
     TemplateRef,
-    ViewChild,
     ViewContainerRef,
     inject,
     input,
+    viewChild,
 } from '@angular/core';
 import { DestroyService } from '@nexplore/practices-ui';
 import { TranslateModule } from '@ngx-translate/core';
@@ -74,54 +73,57 @@ const SIGNPOST_POST_CSS_STYLES: { [K in TooltipDirection]: string } = {
 let nextUniqueId = 0;
 
 @Component({
-    selector: 'puibe-tooltip',
+    selector: 'puibe-tooltip-button',
     imports: [CommonModule, OverlayModule, TranslateModule, PuibeTooltipIconComponent],
     providers: [DestroyService],
     templateUrl: './tooltip.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        class: 'inline',
+    },
 })
-export class PuibeTooltipComponent implements AfterViewInit, OnDestroy {
-    private readonly document = inject<Document>(DOCUMENT);
-    readonly overlayService = inject(Overlay);
-    private readonly destroy$ = inject(DestroyService);
-    readonly viewContainerRef = inject(ViewContainerRef);
-    private readonly cdr = inject(ChangeDetectorRef);
+export class PuibeTooltipButtonComponent implements AfterViewInit, OnDestroy {
+    private readonly _document = inject<Document>(DOCUMENT);
+    private readonly _overlayService = inject(Overlay);
+    private readonly _destroy$ = inject(DestroyService);
+    private readonly _viewContainerRef = inject(ViewContainerRef);
+    private readonly _cdr = inject(ChangeDetectorRef);
 
-    @ViewChild(CdkOverlayOrigin) private readonly origin: CdkOverlayOrigin | undefined;
-    @ViewChild(TemplateRef) private readonly signpostRef: TemplateRef<HTMLDivElement> | undefined;
+    public readonly overlayMaxWidthClass = input<string>('max-w-md');
 
-    public readonly signCssClasses: { [K in TooltipDirection]: string } = SIGNPOST_SIGN_CSS_CLASSES;
-    public readonly tooltipId = `tooltip-${nextUniqueId++}`;
-    public signpostDirection: TooltipDirection = 'top';
-    public postTranslationCssStyle = '';
+    private readonly _origin = viewChild(CdkOverlayOrigin);
+    private readonly _signpostRef = viewChild(TemplateRef<HTMLDivElement>);
 
-    private overlayRef: OverlayRef | undefined;
-    private templatePortal: TemplatePortal<HTMLDivElement> | undefined;
-    private overlayObserver: MutationObserver | undefined;
+    protected readonly signCssClasses: { [K in TooltipDirection]: string } = SIGNPOST_SIGN_CSS_CLASSES;
+    protected readonly tooltipId = `tooltip-${nextUniqueId++}`;
+    protected signpostDirection: TooltipDirection = 'top';
+    protected postTranslationCssStyle = '';
 
-    @HostBinding('class') protected hostClass = 'inline';
+    private _overlayRef: OverlayRef | undefined;
+    private _templatePortal: TemplatePortal<HTMLDivElement> | undefined;
+    private _overlayObserver: MutationObserver | undefined;
+
     @HostListener('document:keydown.escape') onKeydownHandler() {
-        this.overlayRef?.detach();
+        this._overlayRef?.detach();
     }
 
-    public readonly noMaxWidth = input(false);
-
     public toggle() {
-        if (this.overlayRef?.hasAttached()) {
-            this.overlayRef?.detach();
+        if (this._overlayRef?.hasAttached()) {
+            this._overlayRef?.detach();
             return;
         }
-        this.overlayRef?.attach(this.templatePortal);
+        this._overlayRef?.attach(this._templatePortal);
     }
 
     public ngAfterViewInit(): void {
-        if (!this.signpostRef) {
+        const signpostRef = this._signpostRef();
+        if (!signpostRef) {
             return;
         }
 
-        this.templatePortal = new TemplatePortal(this.signpostRef, this.viewContainerRef);
+        this._templatePortal = new TemplatePortal(signpostRef, this._viewContainerRef);
 
-        const scrollStrategy = this.overlayService.scrollStrategies.close();
+        const scrollStrategy = this._overlayService.scrollStrategies.close();
 
         const overlayConfig = {
             hasBackdrop: true,
@@ -129,15 +131,15 @@ export class PuibeTooltipComponent implements AfterViewInit, OnDestroy {
             scrollStrategy,
         };
 
-        this.overlayRef = this.overlayService.create(overlayConfig);
+        this._overlayRef = this._overlayService.create(overlayConfig);
 
-        this.overlayRef
+        this._overlayRef
             .backdropClick()
-            .pipe(takeUntil(this.destroy$))
-            .subscribe(() => this.overlayRef?.detach());
+            .pipe(takeUntil(this._destroy$))
+            .subscribe(() => this._overlayRef?.detach());
 
-        this.overlayObserver = new MutationObserver(() => this.setOverlayDirection());
-        this.overlayObserver.observe(this.overlayRef.overlayElement, {
+        this._overlayObserver = new MutationObserver(() => this.setOverlayDirection());
+        this._overlayObserver.observe(this._overlayRef.overlayElement, {
             attributes: false,
             childList: true,
             subtree: false,
@@ -145,38 +147,39 @@ export class PuibeTooltipComponent implements AfterViewInit, OnDestroy {
     }
 
     public ngOnDestroy(): void {
-        this.overlayRef?.dispose();
-        this.overlayObserver?.disconnect();
+        this._overlayRef?.dispose();
+        this._overlayObserver?.disconnect();
     }
 
     private setOverlayDirection() {
-        if (!this.origin || !this.overlayRef) {
+        const origin = this._origin();
+        if (!origin || !this._overlayRef) {
             return;
         }
-        if (!this.overlayRef.hasAttached()) {
+        if (!this._overlayRef.hasAttached()) {
             return;
         }
 
-        this.findOverlayDirection(this.origin, this.overlayRef);
+        this.findOverlayDirection(origin, this._overlayRef);
 
-        const positionStrategy = this.overlayService
+        const positionStrategy = this._overlayService
             .position()
-            .flexibleConnectedTo(this.origin.elementRef)
+            .flexibleConnectedTo(origin.elementRef)
             .withFlexibleDimensions(true)
             .withPush(true)
             .withGrowAfterOpen(true)
             .withPositions([OVERLAY_POSITIONS[this.signpostDirection]]);
 
-        this.overlayRef.updatePositionStrategy(positionStrategy);
-        this.overlayRef.updatePosition();
+        this._overlayRef.updatePositionStrategy(positionStrategy);
+        this._overlayRef.updatePosition();
 
-        this.setPostOffset(this.origin, this.overlayRef);
+        this.setPostOffset(origin, this._overlayRef);
 
-        this.cdr.detectChanges();
+        this._cdr.detectChanges();
     }
 
     private findOverlayDirection(origin: CdkOverlayOrigin, overlayRef: OverlayRef) {
-        const defaultWindow = this.document.defaultView;
+        const defaultWindow = this._document.defaultView;
         if (defaultWindow) {
             // Determine the direction of the signpost, based on the space around the origin and the size of the overlay
             const { top, left, width, height } = origin.elementRef.nativeElement.getBoundingClientRect();
@@ -224,4 +227,3 @@ export class PuibeTooltipComponent implements AfterViewInit, OnDestroy {
             }[this.signpostDirection] + SIGNPOST_POST_CSS_STYLES[this.signpostDirection];
     }
 }
-

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
@@ -89,10 +89,10 @@ export class PuibeTooltipButtonComponent implements AfterViewInit, OnDestroy {
     private readonly _viewContainerRef = inject(ViewContainerRef);
     private readonly _cdr = inject(ChangeDetectorRef);
 
-    public readonly overlayMaxWidthClass = input<string>('max-w-md');
+    public readonly overlayMaxWidthClassSignal = input<string>('max-w-md', { alias: 'overlayMaxWidthClass' });
 
-    private readonly _origin = viewChild(CdkOverlayOrigin);
-    private readonly _signpostRef = viewChild(TemplateRef<HTMLDivElement>);
+    private readonly _originSignal = viewChild(CdkOverlayOrigin);
+    private readonly _signpostRefSignal = viewChild(TemplateRef<HTMLDivElement>);
 
     protected readonly signCssClasses: { [K in TooltipDirection]: string } = SIGNPOST_SIGN_CSS_CLASSES;
     protected readonly tooltipId = `tooltip-${nextUniqueId++}`;
@@ -116,7 +116,7 @@ export class PuibeTooltipButtonComponent implements AfterViewInit, OnDestroy {
     }
 
     public ngAfterViewInit(): void {
-        const signpostRef = this._signpostRef();
+        const signpostRef = this._signpostRefSignal();
         if (!signpostRef) {
             return;
         }
@@ -152,7 +152,7 @@ export class PuibeTooltipButtonComponent implements AfterViewInit, OnDestroy {
     }
 
     private setOverlayDirection() {
-        const origin = this._origin();
+        const origin = this._originSignal();
         if (!origin || !this._overlayRef) {
             return;
         }


### PR DESCRIPTION
## Description

Renders the radio-button description as a tooltip instead of inline text, so long descriptions no longer clutter the option layout. Brings over a reusable tooltip component (and tooltip-icon) from KOS to back this behavior, and updates the Storybook example accordingly.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified the radio-button tooltip behavior visually through the updated Storybook story.

## Integration Instructions

N/A — the change is additive. The new tooltip component is available for reuse, and existing radio-button usages automatically render their description as a tooltip.