### PR TITLE
fix memory leak in syncfusion.excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Practices.Syncfusion.Excel` Fixed registration for ExcelEngine (memory leak)
+
 ## [11.2.1](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.1) - 2026-04-17
 
 ### Changed

--- a/dotnet/src/Nexplore.Practices.Syncfusion.Excel/ExcelExporter.cs
+++ b/dotnet/src/Nexplore.Practices.Syncfusion.Excel/ExcelExporter.cs
@@ -46,6 +46,7 @@ namespace Nexplore.Practices.Syncfusion.Excel
         {
             var workbook = await this.ConvertToExcelAsync(entities, config, localizer, cancellationToken).ConfigureAwait(false);
             workbook.SaveAs(outputStream);
+            workbook.Close();
         }
 
         public async Task<Stream> ExportAsync<TEntity>(IAsyncEnumerable<TEntity> entities, IExportConfig<TEntity> config, IStringLocalizer localizer, CancellationToken cancellationToken)
@@ -60,6 +61,7 @@ namespace Nexplore.Practices.Syncfusion.Excel
         {
             var workbook = await this.ConvertToExcelAsync(entities, config, localizer, cancellationToken).ConfigureAwait(false);
             workbook.SaveAs(outputStream);
+            workbook.Close();
         }
 
         private Task<IWorkbook> ConvertToExcelAsync<TEntity>(IEnumerable<TEntity> entities, IExportConfig<TEntity> config, IStringLocalizer localizer, CancellationToken cancellationToken)
@@ -174,6 +176,7 @@ namespace Nexplore.Practices.Syncfusion.Excel
         {
             var stream = new MemoryStream();
             workbook.SaveAs(stream);
+            workbook.Close();
 
             Guard.ArgumentAssert(stream.CanSeek, "stream.CanSeek", nameof(stream));
             stream.Position = 0;

--- a/dotnet/src/Nexplore.Practices.Syncfusion.Excel/Registry.cs
+++ b/dotnet/src/Nexplore.Practices.Syncfusion.Excel/Registry.cs
@@ -8,10 +8,11 @@ namespace Nexplore.Practices.Syncfusion.Excel
     {
         protected override void Load(ContainerBuilder builder)
         {
+            // Excel engine is disposable and should not be registered as singleton (it keeps a list of all workbooks)
+            builder.RegisterType<ExcelEngine>().AsSelf().InstancePerLifetimeScope();
             builder.RegisterType<ExcelExporter>().As<IExcelExporter>().InstancePerLifetimeScope();
             builder.RegisterType<DefaultExportConfigFactory>().As<IExportConfigFactory>().SingleInstance();
             builder.RegisterType<DefaultExcelFormats>().As<IExcelFormats>().SingleInstance();
-            builder.RegisterType<ExcelEngine>().AsSelf().SingleInstance();
         }
     }
 }


### PR DESCRIPTION
Fixes #
`Practices.Syncfusion.Excel` Fixed registration for ExcelEngine (memory leak)
