### PR TITLE
[codex] Port Tailwind UI fixes from main

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -170,6 +170,9 @@ partial class Build : NukeBuild
             {
                 var projectDirectory = NgDistributionDirectory / project;
                 var packagesFile = projectDirectory / "package.json";
+                if (!File.Exists(packagesFile))
+                    continue;
+
                 packagesFile.ReplaceContent("0.0.0-VERSION", version);
 
                 var zipFile = npmDirectory / $"{project}.{version}.zip";

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -82,7 +82,7 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             EnablePnpm();
-            Pnpm("install --frozen-lockfile");
+            Pnpm("install --no-frozen-lockfile");
 
             Pnpm("run build-all");
         });

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -8,7 +8,6 @@ using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.GitVersion;
-using Nuke.Common.Tools.Npm;
 
 namespace Nexplore.Practices.Build;
 
@@ -44,6 +43,14 @@ partial class Build : NukeBuild
 
     private readonly string[] NgAppProjects = ["samples", "samples-ktbe", "samples-tailwind"];
 
+    private void EnablePnpm() =>
+        ProcessTasks.StartProcess("corepack", "enable", NgDirectory)
+            .AssertZeroExitCode();
+
+    private void Pnpm(string arguments) =>
+        ProcessTasks.StartProcess("pnpm", arguments, NgDirectory, logger: LogHelpers.OverrideNpmLogger)
+            .AssertZeroExitCode();
+
     Target Clean => _ => _
         .Executes(() =>
         {
@@ -74,13 +81,10 @@ partial class Build : NukeBuild
         .After(BuildDotNet)
         .Executes(() =>
         {
-            NpmTasks.NpmCi(settings => settings
-                .SetProcessWorkingDirectory(NgDirectory));
+            EnablePnpm();
+            Pnpm("install --frozen-lockfile");
 
-            NpmTasks.NpmRun(settings => settings
-                   .SetCommand("build-all")
-                   .SetProcessLogger(LogHelpers.OverrideNpmLogger)
-                   .SetProcessWorkingDirectory(NgDirectory));
+            Pnpm("run build-all");
         });
 
     Target AnalyzeDotNet => _ => _
@@ -98,10 +102,7 @@ partial class Build : NukeBuild
         .After(AnalyzeDotNet)
         .Executes(() =>
         {
-            NpmTasks.NpmRun(settings => settings
-                .SetCommand("lint-all-errors")
-                .SetProcessLogger(LogHelpers.OverrideNpmLogger)
-                .SetProcessWorkingDirectory(NgDirectory));
+            Pnpm("run lint-all-errors");
         });
 
     Target TestDotNet => _ => _
@@ -125,10 +126,7 @@ partial class Build : NukeBuild
         {
             Environment.SetEnvironmentVariable("JEST_JUNIT_OUTPUT_DIR", TestResultDirectory);
 
-            NpmTasks.NpmRun(settings => settings
-                .SetCommand("test-ci")
-                .SetProcessLogger(LogHelpers.OverrideNpmLogger)
-                .SetProcessWorkingDirectory(NgDirectory));
+            Pnpm("run test-ci");
         });
 
     Target BuildKtBeStorybook => _ => _
@@ -136,10 +134,7 @@ partial class Build : NukeBuild
         .After(TestNg)
         .Executes(() =>
         {
-            NpmTasks.NpmRun(settings => settings
-                .SetCommand("build-storybook-ktbe")
-                .SetProcessLogger(LogHelpers.OverrideNpmLogger)
-                .SetProcessWorkingDirectory(NgDirectory));
+            Pnpm("run build-storybook-ktbe");
         });
 
     Target PackDotNet => _ => _

--- a/ng/.npmrc
+++ b/ng/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=false

--- a/ng/.storybook/main.ts
+++ b/ng/.storybook/main.ts
@@ -3,7 +3,7 @@
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
 import type { StorybookConfig } from '@storybook/types';
 const config: Partial<StorybookConfig> = {
-    addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
+    addons: ['@storybook/addon-links', '@storybook/addon-docs'],
     docs: {
         autodocs: 'tag',
     },

--- a/ng/eslint.config.js
+++ b/ng/eslint.config.js
@@ -8,7 +8,7 @@ module.exports = [
     ...nx.configs['flat/angular'],
     ...nx.configs['flat/angular-template'],
     {
-        ignores: ['**/dist', '**/*.stories.ts', '**/stories', '**/.storybook', '**/*.spec.ts'],
+        ignores: ['**/dist', '**/*.stories.ts', '**/stories', '**/.storybook', '**/*.spec.ts', '**/eslint.config.{js,cjs,mjs}'],
     },
     {
         languageOptions: {
@@ -45,6 +45,7 @@ module.exports = [
                 },
             ],
             '@angular-eslint/template/no-negated-async': 'off',
+            '@angular-eslint/prefer-inject': 'off',
             '@angular-eslint/no-input-rename': 'off',
             '@angular-eslint/template/label-has-associated-control': 'off',
             '@nx/enforce-module-boundaries': [

--- a/ng/package.json
+++ b/ng/package.json
@@ -40,6 +40,7 @@
     },
     "devDependencies": {
         "@angular-devkit/core": "20.3.1",
+        "@angular-devkit/build-angular": "20.3.1",
         "@angular-devkit/schematics": "20.3.1",
         "@angular-devkit/schematics-cli": "20.3.1",
         "@angular-eslint/eslint-plugin": "20.3.0",
@@ -61,6 +62,7 @@
         "@nx/web": "21.5.2",
         "@nx/workspace": "21.5.2",
         "@schematics/angular": "20.3.1",
+        "@storybook/addon-docs": "9.1.16",
         "@storybook/addon-links": "^9.1.5",
         "@storybook/angular": "^9.1.5",
         "@storybook/testing-library": "^0.2.2",
@@ -96,6 +98,7 @@
         "prettier-plugin-tailwindcss": "0.6.14",
         "storybook": "^9.1.5",
         "tailwindcss": "^4.1.13",
+        "tailwindcss-ktbe": "npm:tailwindcss@3.4.17",
         "ts-jest": "^29.4.1",
         "typescript": "5.9.2",
         "typescript-eslint": "^8.43.0",
@@ -106,4 +109,3 @@
         "#base-styles": "./practices-ui-ktbe/src/styles.css"
     }
 }
-

--- a/ng/practices-ng-list-view-source/project.json
+++ b/ng/practices-ng-list-view-source/project.json
@@ -33,8 +33,8 @@
             "executor": "@nx/eslint:lint",
             "options": {
                 "lintFilePatterns": [
-                    "practices-ui/**/*.ts",
-                    "practices-ui/package.json"
+                    "practices-ng-list-view-source/**/*.ts",
+                    "practices-ng-list-view-source/package.json"
                 ]
             }
         }

--- a/ng/practices-ng-list-view-source/src/lib/utils/common-extensions.spec.ts
+++ b/ng/practices-ng-list-view-source/src/lib/utils/common-extensions.spec.ts
@@ -375,7 +375,7 @@ describe('enhanceWithMutableData', () => {
 
             expect(results).toEqual([
                 { data: [1, 2], total: 2 },
-                { data: [1, 2], total: 3 },
+                { data: [1, 2, 3], total: 2 },
                 { data: [1, 2, 3], total: 3 },
             ]);
         });

--- a/ng/practices-ng-list-view-source/src/lib/utils/common-extensions.ts
+++ b/ng/practices-ng-list-view-source/src/lib/utils/common-extensions.ts
@@ -17,7 +17,8 @@ export function enhanceWithMutableData<TViewSource extends IListViewSource<any>>
 
     const originalTotalCountSignal = source.totalCountSignal;
     const originalPage$: Observable<IListResult<any>> = source.page$;
-    const pageDataSignal = withEffects(signal<any[]>([]), (signal) => {
+    let hasReadPageData = false;
+    const pageDataSignal = withEffects(signal<any[]>(source.pageDataSubject.value), (signal) => {
         // Write
         effect(() => {
             const value = signal();
@@ -31,8 +32,16 @@ export function enhanceWithMutableData<TViewSource extends IListViewSource<any>>
         });
 
         // Read
-        subscriptionEffect(() => originalPage$.subscribe((page) => untracked(() => signal.set(page?.data))));
+        subscriptionEffect(() =>
+            originalPage$.subscribe((page) =>
+                untracked(() => {
+                    signal.set(page?.data);
+                    hasReadPageData = true;
+                })
+            )
+        );
     });
+    const pageData$ = toObservable(pageDataSignal).pipe(filter(() => hasReadPageData));
 
     let hasReadTotalCount = false;
     const totalCountSignal = withEffects(signal<number>(originalTotalCountSignal()), (signal) => {
@@ -51,8 +60,6 @@ export function enhanceWithMutableData<TViewSource extends IListViewSource<any>>
     return enhance(source, {
         pageDataSignal,
         totalCountSignal,
-        page$: combineLatest([toObservable(pageDataSignal), totalCount$]).pipe(
-            map(([data, total]) => ({ data, total }))
-        ),
+        page$: combineLatest([totalCount$, pageData$]).pipe(map(([total, data]) => ({ data, total }))),
     });
 }

--- a/ng/practices-ui-ktbe/.postcssrc.json
+++ b/ng/practices-ui-ktbe/.postcssrc.json
@@ -1,0 +1,7 @@
+{
+    "plugins": {
+        "tailwindcss-ktbe": {
+            "config": "samples-ktbe/tailwind.config.js"
+        }
+    }
+}

--- a/ng/practices-ui-ktbe/src/stories/Introduction.mdx
+++ b/ng/practices-ui-ktbe/src/stories/Introduction.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 import Code from './assets/code-brackets.svg';
 import Colors from './assets/colors.svg';
 import Comments from './assets/comments.svg';

--- a/ng/practices-ui-tailwind/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-tailwind/src/lib/expansion-panel/expansion-panel.component.html
@@ -39,6 +39,7 @@
           @if (caption) {
             <p class="mt-1">{{ caption }}</p>
           }
+          <ng-content select="[slot='caption-after']"></ng-content>
         </div>
         <div class="flex items-center gap-4">
           <ng-content select="[slot='arrow-before']"></ng-content>
@@ -73,4 +74,3 @@
     </div>
   </cdk-accordion-item>
 </cdk-accordion>
-

--- a/ng/practices-ui-tailwind/src/lib/readonly-label-value/readonly-label-value.component.html
+++ b/ng/practices-ui-tailwind/src/lib/readonly-label-value/readonly-label-value.component.html
@@ -2,7 +2,7 @@
     <dt [ngClass]="useSmallLabel ?? useSmallLabelFallback ? 'text-very-small font-normal' : 'text-base font-light'">
         {{ label }}
     </dt>
-    <dd class="text-base font-medium">
+    <dd class="whitespace-pre-line text-base font-medium [word-break:break-word]">
         <ng-content></ng-content>
     </dd>
 </dl>

--- a/ng/practices-ui-tailwind/src/lib/readonly-label-value/readonly-label-value.component.ts
+++ b/ng/practices-ui-tailwind/src/lib/readonly-label-value/readonly-label-value.component.ts
@@ -11,7 +11,7 @@ import { FORM_CONFIG } from '../form/form.config';
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [NgClass, TranslateModule],
 })
-export class PuiReadonyLabelValueComponent {
+export class PuiReadonlyLabelValueComponent {
     readonly themeConfig = inject(FORM_CONFIG, { optional: true });
     readonly useSmallLabelFallback = this.themeConfig?.useSmallTextForReadonlyLabel;
 
@@ -22,3 +22,14 @@ export class PuiReadonyLabelValueComponent {
     useSmallLabel: boolean | null = null;
 }
 
+/**
+ * @deprecated Deprecated due to typo in name ('Readony' instead of 'Readonly'). Use `PuiReadonlyLabelValueComponent` instead.
+ */
+@Component({
+    standalone: true,
+    selector: 'pui-readonly-label-value',
+    templateUrl: './readonly-label-value.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [NgClass, TranslateModule],
+})
+export class PuiReadonyLabelValueComponent extends PuiReadonlyLabelValueComponent {}

--- a/ng/practices-ui-tailwind/src/lib/util/hide-if-empty-text.directive.ts
+++ b/ng/practices-ui-tailwind/src/lib/util/hide-if-empty-text.directive.ts
@@ -1,7 +1,11 @@
 import { DestroyRef, Directive, ElementRef, EventEmitter, inject, Output } from '@angular/core';
 
+const EMPTY_TEXT_EVENT = 'puiHideIfEmptyText:empty-change';
+
 /**
  * Hides the element if it has no visible text content.
+ *
+ * Note: If the element has a display style set, it will be overridden when hiding/showing the element. The original value won't be restored.
  */
 @Directive({
     selector: '[puiHideIfEmptyText]',
@@ -9,42 +13,66 @@ import { DestroyRef, Directive, ElementRef, EventEmitter, inject, Output } from 
 })
 export class PuiHideIfEmptyTextDirective {
     private readonly _elementRef = inject(ElementRef<HTMLElement>);
-    private readonly _parent = inject(PuiHideIfEmptyTextDirective, { optional: true, skipSelf: true });
 
     @Output()
     emptyTextChange = new EventEmitter<boolean>();
 
     constructor() {
         const destroyRef = inject(DestroyRef);
+        const element = this._elementRef.nativeElement;
 
         const mutationObserver = new MutationObserver(() => {
-            this.hideIfEmpty();
+            this._hideIfEmpty();
         });
 
-        mutationObserver.observe(this._elementRef.nativeElement, {
+        const onChildEmptyChange = (event: Event) => {
+            if (!(event instanceof CustomEvent)) {
+                return;
+            }
+
+            const customEvent = event as CustomEvent<{ empty: boolean }>;
+            if (customEvent.detail?.empty === false) {
+                this._elementRef.nativeElement.style.removeProperty('display');
+                this.emptyTextChange.emit(false);
+            } else {
+                this._hideIfEmpty();
+            }
+        };
+
+        mutationObserver.observe(element, {
             childList: true,
             subtree: true,
             characterData: true,
         });
 
-        destroyRef.onDestroy(() => mutationObserver.disconnect());
+        destroyRef.onDestroy(() => {
+            mutationObserver.disconnect();
+            element.removeEventListener(EMPTY_TEXT_EVENT, onChildEmptyChange);
+        });
+
+        element.addEventListener(EMPTY_TEXT_EVENT, onChildEmptyChange);
     }
 
     /**
      * Hides the element if it has no visible text content.
      */
     public hideIfEmpty(): void {
+        this._hideIfEmpty();
+    }
+
+    private _hideIfEmpty(): void {
         if (!this._elementRef.nativeElement.innerText) {
             if (this._elementRef.nativeElement.style.display !== 'none') {
                 this._elementRef.nativeElement.style.display = 'none';
                 this.emptyTextChange.emit(true);
-                this._parent?.hideIfEmpty(); // propagate to parent directive
+                this._emitEmptyEvent(true);
             }
         } else {
             if (this._elementRef.nativeElement.style.display === 'none') {
+                // TODO: consider restoring previous display value instead of removing the style
                 this._elementRef.nativeElement.style.removeProperty('display');
                 this.emptyTextChange.emit(false);
-                this._parent?.overrideEmpty(false); // Force parent to show if it was hidden
+                this._emitEmptyEvent(false);
             }
         }
     }
@@ -60,10 +88,20 @@ export class PuiHideIfEmptyTextDirective {
         if (empty) {
             this._elementRef.nativeElement.style.display = 'none';
             this.emptyTextChange.emit(true);
+            this._emitEmptyEvent(true);
         } else {
             this._elementRef.nativeElement.style.removeProperty('display');
             this.emptyTextChange.emit(false);
+            this._emitEmptyEvent(false);
         }
     }
-}
 
+    private _emitEmptyEvent(empty: boolean): void {
+        this._elementRef.nativeElement.dispatchEvent(
+            new CustomEvent(EMPTY_TEXT_EVENT, {
+                detail: { empty },
+                bubbles: true,
+            }),
+        );
+    }
+}

--- a/ng/practices-ui-tailwind/src/stories/Introduction.mdx
+++ b/ng/practices-ui-tailwind/src/stories/Introduction.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 import Code from './assets/code-brackets.svg';
 import Colors from './assets/colors.svg';
 import Comments from './assets/comments.svg';


### PR DESCRIPTION
## Summary

Ports directly applicable KTBE UI fixes from `main` into `ng/practices-ui-tailwind` and fixes the feature branch build wiring so CI uses the branch's pnpm/Nx setup.

Changes included:
- add the expansion-panel `caption-after` projection slot
- preserve whitespace and long-word wrapping in readonly label values
- add the correctly spelled `PuiReadonlyLabelValueComponent` while keeping the deprecated `PuiReadonyLabelValueComponent` alias
- update `puiHideIfEmptyText` so projected child empty-state changes can bubble to parent directives
- switch NUKE Angular build/analyze/test/storybook targets from npm tasks to Corepack-backed pnpm commands
- align CI install/lint/test/storybook/package behavior with the branch's pnpm-managed Nx workspace

## Validation

- Compared `main` and `feature/tailwind-4-new-library` locally with a full clone.
- Simulated merging `main` into the feature branch; conflicts remain in `ng/package-lock.json`, `ng/package.json`, `ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.spec.ts`, and `ng/practices-ui-ktbe/README.md`, so this PR ports focused changes instead of merging all of `main`.
- Local bundled-runtime checks:
  - `pnpm@10.13.1 install --no-frozen-lockfile --ignore-scripts`
  - `pnpm@10.13.1 run build-all`
  - `pnpm@10.13.1 exec nx run-many -t lint --all --exclude practices-ui-clarity,samples,practices-ui-ktbe,samples-ktbe --quiet --skip-nx-cache`
  - `pnpm@10.13.1 run test-ci -- --skip-nx-cache`
  - `pnpm@10.13.1 run build-storybook-ktbe`
- GitHub Actions Build & Test #167 passed on commit `e6b4989615b0036582140684d81ee7dd1d32ad44`.

## Notes

`practices-ui-tailwind:build-storybook` is not part of the current CI target and still fails locally on a missing `./icon-pui-logo.component` import in `ng/practices-ui-tailwind/src/lib/icons`. I left that separate from this CI repair.