### PR TITLE
Fix initial Tailwind checkbox touched state

### DIFF
--- a/ng/practices-ui-tailwind/src/lib/checkbox/checkbox.component.spec.ts
+++ b/ng/practices-ui-tailwind/src/lib/checkbox/checkbox.component.spec.ts
@@ -1,0 +1,127 @@
+import 'jest-preset-angular/setup-env/zone';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { createEnvironmentInjector, ElementRef, runInInjectionContext } from '@angular/core';
+import { FormControl, NgControl, Validators } from '@angular/forms';
+import { BehaviorSubject, of } from 'rxjs';
+import { PuiFormFieldService } from '@nexplore/practices-ng-forms';
+import { FORM_CONFIG } from '../form/form.config';
+import { PuiCheckboxComponent } from './checkbox.component';
+
+function createCheckbox(control: FormControl<boolean | null> | null = new FormControl(false)) {
+    const injector = createEnvironmentInjector([
+        { provide: ElementRef, useValue: new ElementRef(document.createElement('input')) },
+        {
+            provide: PuiFormFieldService,
+            useValue: {
+                isRequired$: of(false),
+                registerNgControl: () => undefined,
+            },
+        },
+        { provide: FORM_CONFIG, useValue: { hideInvalidIfUntouched: true } },
+    ], null as never);
+
+    const checkbox = runInInjectionContext(injector, () => new PuiCheckboxComponent());
+    const ngControl = {
+        control,
+        get touched() {
+            return control?.touched ?? false;
+        },
+        get status() {
+            return control?.status ?? 'VALID';
+        },
+        get value() {
+            return control?.value;
+        },
+        get errors() {
+            return control?.errors;
+        },
+        valueChanges: control?.valueChanges ?? null,
+        statusChanges: control?.statusChanges ?? null,
+    } as unknown as NgControl;
+
+    (checkbox as unknown as { _ngControlSubject: BehaviorSubject<NgControl | null> })._ngControlSubject.next(ngControl);
+
+    return { checkbox, control };
+}
+
+const waitForDelayedNgControl = () => new Promise((resolve) => setTimeout(resolve));
+
+describe('PuiCheckboxComponent', () => {
+    beforeEach(() => undefined);
+
+    it('emits false for an initially untouched control', async () => {
+        const { checkbox } = createCheckbox();
+        const touchedStates: boolean[] = [];
+
+        const subscription = checkbox.touched$.subscribe((touched) => touchedStates.push(touched));
+        await waitForDelayedNgControl();
+
+        expect(touchedStates).toEqual([false]);
+        subscription.unsubscribe();
+    });
+
+    it('emits true for a control that is already touched when attached', async () => {
+        const control = new FormControl(false);
+        control.markAsTouched();
+        const { checkbox } = createCheckbox(control);
+        const touchedStates: boolean[] = [];
+
+        const subscription = checkbox.touched$.subscribe((touched) => touchedStates.push(touched));
+        await waitForDelayedNgControl();
+
+        expect(touchedStates).toEqual([true]);
+        subscription.unsubscribe();
+    });
+
+    it('emits true when markAsTouched changes the control touched state', async () => {
+        const { checkbox, control } = createCheckbox();
+        const touchedStates: boolean[] = [];
+        const subscription = checkbox.touched$.subscribe((touched) => touchedStates.push(touched));
+        await waitForDelayedNgControl();
+
+        control?.markAsTouched();
+
+        expect(touchedStates).toEqual([false, true]);
+        subscription.unsubscribe();
+    });
+
+    it('emits false when markAsUntouched changes the control touched state back', async () => {
+        const control = new FormControl(false);
+        control.markAsTouched();
+        const { checkbox } = createCheckbox(control);
+        const touchedStates: boolean[] = [];
+        const subscription = checkbox.touched$.subscribe((touched) => touchedStates.push(touched));
+        await waitForDelayedNgControl();
+
+        control.markAsUntouched();
+
+        expect(touchedStates).toEqual([true, false]);
+        subscription.unsubscribe();
+    });
+
+    it('handles a temporarily missing control safely', async () => {
+        const { checkbox } = createCheckbox(null);
+        const touchedStates: boolean[] = [];
+
+        const subscription = checkbox.touched$.subscribe((touched) => touchedStates.push(touched));
+        await waitForDelayedNgControl();
+
+        expect(touchedStates).toEqual([false]);
+        subscription.unsubscribe();
+    });
+
+    it('shows an initially touched invalid checkbox when invalid display is hidden until touched', async () => {
+        const control = new FormControl(false, { validators: Validators.requiredTrue });
+        control.markAsTouched();
+        const { checkbox } = createCheckbox(control);
+        const displayAsInvalidStates: boolean[] = [];
+
+        const subscription = checkbox.displayAsInvalid$.subscribe((displayAsInvalid) =>
+            displayAsInvalidStates.push(displayAsInvalid),
+        );
+        await waitForDelayedNgControl();
+
+        expect(displayAsInvalidStates).toContain(true);
+        subscription.unsubscribe();
+    });
+});

--- a/ng/practices-ui-tailwind/src/lib/checkbox/checkbox.component.ts
+++ b/ng/practices-ui-tailwind/src/lib/checkbox/checkbox.component.ts
@@ -20,7 +20,7 @@ import {
 import { PuiFormFieldDirective, PuiFormFieldService, PuiReadonlyDirective } from '@nexplore/practices-ng-forms';
 import { DestroyService } from '@nexplore/practices-ui';
 import { TranslateModule } from '@ngx-translate/core';
-import { BehaviorSubject, combineLatest, delay, filter, map, merge, of, shareReplay, startWith, switchMap } from 'rxjs';
+import { BehaviorSubject, combineLatest, delay, EMPTY, filter, map, merge, of, shareReplay, startWith, switchMap } from 'rxjs';
 import { FormFieldStatus } from '../form-field/form-field.service';
 import { FORM_CONFIG, FormConfig } from '../form/form.config';
 import { PuiReadonyLabelValueComponent } from '../readonly-label-value/readonly-label-value.component';
@@ -92,9 +92,15 @@ export class PuiCheckboxComponent implements ControlValueAccessor, AfterViewInit
     readonly isRequired$ = this._formFieldService.isRequired$;
 
     readonly touched$ = this._ngControl$.pipe(
-        switchMap((ngControl) => ngControl.control?.events ?? []),
-        filter((event) => event instanceof TouchedChangeEvent),
-        map((event) => event.touched),
+        switchMap((ngControl) =>
+            merge(
+                of(ngControl.control?.touched ?? ngControl.touched ?? false),
+                (ngControl.control?.events ?? EMPTY).pipe(
+                    filter((event) => event instanceof TouchedChangeEvent),
+                    map((event) => event.touched),
+                ),
+            ),
+        ),
     );
 
     readonly isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);


### PR DESCRIPTION
## Summary

- Emit the checkbox control's current touched state immediately, before subsequent `TouchedChangeEvent` updates.
- Safely emit `false` when a control is temporarily unavailable.
- Add focused coverage for initial touched/untouched state, touched-state transitions, missing controls, and invalid display behavior.

## Source

This reconciles the ready Codex Cloud result from [task_e_6a38c615c1808325892edebd5a69e104](https://chatgpt.com/codex/tasks/task_e_6a38c615c1808325892edebd5a69e104). The earlier one-file result from [task_e_6a379050bc7483258842e75542fabccb](https://chatgpt.com/codex/tasks/task_e_6a379050bc7483258842e75542fabccb) was also inspected and is superseded by this focused implementation plus tests.

## Verification

Codex Cloud on the exact branch snapshot reported:

- Focused checkbox Jest run: 6 tests passed.
- `nx test practices-ui-tailwind --runInBand --ci`: 3 suites / 52 tests passed.
- `nx lint practices-ui-tailwind`: passed with existing warnings only.
- `nx build practices-ui-tailwind --configuration=production`: passed.
- Changed-file `git diff --check`: passed.

Published verification:

- Published blob SHAs match the Cloud diff: `0bffbdc5e0a786b701a324d32351bd0b538694bd` and `a06da39974402489d40532698000c7a8379cbd39`.
- GitHub Actions [Build & Test run 176](https://github.com/nexplore/nexplore-practices/actions/runs/27935852607) passed, including `./build.sh BuildPackAll`.
- No build, lint, Jest, or Storybook command was run locally because this machine has no Node/npm/pnpm.
- Cloud remains unable to fetch remote refs; no cross-branch verification is claimed from Cloud.

## Parent branch status

This PR intentionally targets `feature/tailwind-4-new-library` only and is merge-clean against that parent. Against repository default branch `main`, the stacked head remains 22 commits ahead and 16 behind, with conflicts in `CHANGELOG.md`, `ng/package-lock.json`, `ng/package.json`, `ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.spec.ts`, and `ng/practices-ui-ktbe/README.md`. The parent branch's inherited whitespace/EOF churn also remains unresolved.