### PR TITLE
docs: sync Angular documentation paths

### DIFF
--- a/docs/Practices.Ui/Installation.md
+++ b/docs/Practices.Ui/Installation.md
@@ -22,28 +22,28 @@ How to install these libraries in your projects
 
 ## practices-ui
 
-- Make sure your project has the peer dependencies in `projects/practices-ui/package.json` installed
+- Make sure your project has the peer dependencies in `ng/practices-ui/package.json` installed
 - `npm install --save @nexplore/practices-ui`
 - Add `providePractices({...})` to the providers array in your main.ts
 
 ## practices-ui-clarity
 
-- Make sure your project has the peer dependencies in `projects/practices-ui-clarity/package.json` installed
+- Make sure your project has the peer dependencies in `ng/practices-ui-clarity/package.json` installed
 - Make sure to follow the official [Clarity Installation Guide](https://clarity.design/documentation/get-started) to install Clarity in your project
 - `npm install --save @nexplore/practices-ui-clarity`
 
 ## practices-ui-ktbe
 
 - practices-ui-ktbe is based on TailwindCSS. Follow the offical TailwindCSS [Installation Guide](https://tailwindcss.com/docs/guides/angular)
-- Make sure your project has the peer dependencies in `projects/practices-ui-ktbe/package.json` installed
+- Make sure your project has the peer dependencies in `ng/practices-ui-ktbe/package.json` installed
 - `npm install --save @nexplore/practices-ui-ktbe`
 - Adjust your `tailwind.config.js`:
-  - Copy the `projects/samples-ktbe/tailwind.config.js` into your project
+  - Copy the `ng/samples-ktbe/tailwind.config.js` into your project
   - Adapt the import of the ktbeTheme: `const ktbeTheme = require('./node_modules/@nexplore/practices-ui-ktbe/tailwind.config.js');`
   - Adapt the `content: []` section: `content: ['./node_modules/@nexplore/practices-ui-ktbe/esm2020/**/*.mjs', './src/**/*.{html,ts}'],`
 - Adjust your styles and add the fonts:
-  - Copy the Roboto-Fonts in `projects/samples-ktbe/src/assets/fonts` into your project
-  - Copy the CSS in `projects/samples-ktbe/src/styles.css` into your projects main CSS and adjust the paths to the font files
+  - Copy the Roboto-Fonts in `ng/samples-ktbe/src/assets/fonts` into your project
+  - Copy the CSS in `ng/samples-ktbe/src/styles.css` into your projects main CSS and adjust the paths to the font files
 - Adjust your main.ts: Add `providePracticesKtbe({...}` to the providers array
 - You may also need the `provideAnimations()` from `@angular/platform-browser/animations`.
 
@@ -57,4 +57,3 @@ How to install these libraries in your projects
 - `npm install --save @nexplore/practices-ng-logging`
 - `npm install --save @nexplore/practices-ng-signals`
 - `npm install --save @nexplore/practices-ng-status`
-- `npm install --save @nexplore/practices-ng-status-types`

--- a/docs/Practices.Ui/Translations.md
+++ b/docs/Practices.Ui/Translations.md
@@ -14,38 +14,58 @@ Practices.UI utilizes these prefixes for the keys:
 
 ## Configuration
 
-If you want to rewrite the prefixes, you can do so by providing a rewrite configuration to `providePractices()`.
-Such a config requires a key, which represents the prefix you want to rewrite and an object with a `rewriteTo` property
-and an optional `fallbackTo` property:
+If you want to rewrite the prefixes, you can do so by passing `rewriteResourceConfig` to `providePractices()`.
+Its `rewriteTypeConfig` maps each prefix you want to rewrite to an object with a `rewriteTo` property and an optional
+`fallbackTo` property:
 
 ```ts
 ...
 bootstrapApplication(AppComponent, {
     providers: [
         providePractices({
-            rewriteResourceTypes: {
-                "Practices": {
-                    rewriteTo: "MyApp",
-                    fallbackTo: "MyGeneral"
+            rewriteResourceConfig: {
+                rewriteTypeConfig: {
+                    Practices: {
+                        rewriteTo: 'MyApp',
+                        fallbackTo: 'MyGeneral',
+                    },
+                    Messages: {
+                        rewriteTo: 'MyMessages',
+                    },
                 },
-                "Messages": {
-                    rewriteTo: "MyMessages",
-                }
-            }
-        })
-    ]
+            },
+        }),
+    ],
 });
 ```
 
-This will inject a custom `TranslateParser` (`RewriteTranslateParser`) which will rewrite keys if it encouters a key with a prefix which is configured in `rewriteResourceTypes`.
+This configures `RewriteMissingTranslationHandler` as ngx-translate's `MissingTranslationHandler`. When ngx-translate
+cannot resolve a key, the handler checks its prefix against `rewriteTypeConfig` and tries the corresponding rewritten key.
 
 Some examples for the configuration above:
 
 - `Practices.Labels_Title` -> `MyApp.Labels_Title` -> `MyGeneral.Labels_Title`
 - `Messages.Labels_Title` -> `MyMessages.Labels_Title`
 
-If it fails to resolve the rewritten key for `rewriteTo`, it will try to resolve the key for `fallbackTo`.
-If that fails as well, it will return `undefined`, which is the default behaviour of ngx-translate's [`TranslateDefaultParser`](https://github.com/ngx-translate/core/blob/master/packages/core/lib/translate.parser.ts).
+If the handler cannot resolve the key configured by `rewriteTo`, it tries the key configured by `fallbackTo`, when
+present. If neither key resolves (or the original key has no configured prefix), it returns the original missing key.
+You can optionally set `missingKeyTransformFn` alongside `rewriteTypeConfig` to transform that returned key:
+
+```ts
+providePractices({
+    rewriteResourceConfig: {
+        rewriteTypeConfig: {
+            Practices: {
+                rewriteTo: 'MyApp',
+                fallbackTo: 'MyGeneral',
+            },
+        },
+        missingKeyTransformFn: (key) => `[${key}]`,
+    },
+});
+```
+
+With this function, an unresolved `Practices.Labels_Title` is returned as `[Practices.Labels_Title]`.
 
 ## TitleService
 
@@ -92,7 +112,7 @@ export class SampleComponent implements OnInit {
 
     ngOnInit(): void {
         this.titleService.setTitle('My Custom Title', { localize: false, autoSetBreadcrumbTitle: false }); // <-- Set a custom title, which is not localized and does not set the breadcrumb title
-        this.titleService.setBreadcrumbTitle('My Custom Breadcrumbs Title', { localize: false }, this.router.url); // <-- Set a custom breadcrumb title without localization for a specific route
+        this.titleService.setBreadcrumbTitle('My Custom Breadcrumbs Title', { localize: false, breadcrumbUrl: this.router.url }); // <-- Set a custom breadcrumb title without localization for a specific route
     }
 }
 ```

--- a/ng/practices-ng-common-util/README.md
+++ b/ng/practices-ng-common-util/README.md
@@ -25,7 +25,7 @@ npm install @nexplore/practices-ng-common-util
 
 ## Features and Usage Examples
 
-### Object and Array Comparison - [`isObjShallowEqual`](./src/lib/comparison/object-comparison.ts), [`isObjDeepEqual`](./src/lib/comparison/object-comparison.ts), [`isArrayEqual`](./src/lib/comparison/array-comparison.ts)
+### Object and Array Comparison - [`isObjShallowEqual`](./src/lib/is-obj-shallow-equal.ts), [`isObjDeepEqual`](./src/lib/is-obj-deep-equal.ts), [`isArrayEqual`](./src/lib/is-array-equal.ts)
 
 Utilities for comparing objects and arrays with different levels of strictness:
 
@@ -61,7 +61,7 @@ const array2 = [1, 2, 3];
 const arraysEqual = isArrayEqual(array1, array2); // true
 ```
 
-### Property Access - [`tryGetUntyped`](./src/lib/object/object-utils.ts), [`trySetUntyped`](./src/lib/object/object-utils.ts)
+### Property Access - [`tryGetUntyped`](./src/lib/try-get-untyped.ts), [`trySetUntyped`](./src/lib/try-set-untyped.ts)
 
 Safely access or modify properties on objects that may be null or undefined:
 
@@ -79,7 +79,7 @@ const email = profileData ? tryGetUntyped<string>(profileData, 'email') : undefi
 trySetUntyped(data, 'user', { profile: { email: 'updated@example.com' } });
 ```
 
-### Signal Handling - [`unwrapSignal`](./src/lib/signal/signal-utils.ts), [`unwrapSignalLike`](./src/lib/signal/signal-utils.ts)
+### Signal Handling - [`unwrapSignal`](./src/lib/unwrap-signal.ts), [`unwrapSignalLike`](./src/lib/unwrap-signal-like.ts)
 
 Utilities for working with Angular signals in flexible ways:
 
@@ -116,7 +116,7 @@ const staticNameSignal = computeFormattedName('mary');
 console.log(staticNameSignal()); // "MARY"
 ```
 
-### Observable and Async Utilities - [`isAsyncOrObservable`](./src/lib/observable/observable-utils.ts), [`firstValueFromMaybeAsync`](./src/lib/observable/observable-utils.ts)
+### Observable and Async Utilities - [`isAsyncOrObservable`](./src/lib/is-async-or-observable.ts), [`firstValueFromMaybeAsync`](./src/lib/first-value-from-maybe-async.ts)
 
 Utilities for working with Observables, Promises, and direct values uniformly:
 
@@ -158,7 +158,7 @@ const observable = maybeAsyncToObservable('hello world');
 subscribeAndForget(of('fire and forget'));
 ```
 
-### AbstractStatefulPipe - [`AbstractStatefulPipe`](./src/lib/angular/pipes.ts)
+### AbstractStatefulPipe - [`AbstractStatefulPipe`](./src/lib/abstract-stateful.pipe.ts)
 
 Base class for creating stateful pipes that handle async transformations:
 
@@ -186,7 +186,7 @@ export class CustomFormatPipe extends AbstractStatefulPipe<string, string> {
 }
 ```
 
-### Object Manipulation - [`deepMerge`](./src/lib/object/object-utils.ts), [`enhance`](./src/lib/object/object-utils.ts)
+### Object Manipulation - [`deepMerge`](./src/lib/deep-merge.util.ts), [`enhance`](./src/lib/enhance-util.ts)
 
 Utilities for combining and enhancing objects:
 
@@ -210,7 +210,7 @@ const enhancedUser = enhance(user, {
 console.log(enhancedUser.fullName); // 'Alice (ID: 1)'
 ```
 
-### Array and String Utilities - [`wrapArrayAndFilterFalsyValues`](./src/lib/array/array-utils.ts), [`firstCharToUpper`](./src/lib/string/string-utils.ts)
+### Array and String Utilities - [`wrapArrayAndFilterFalsyValues`](./src/lib/array.util.ts), [`firstCharToUpper`](./src/lib/string.util.ts)
 
 Helper functions for array and string manipulation:
 
@@ -227,7 +227,7 @@ const uppercase = firstCharToUpper('hello'); // 'Hello'
 const lowercase = firstCharToLower('Hello'); // 'hello'
 ```
 
-### Type Utilities - [`StringKeyOf`](./src/lib/types/type-utils.ts)
+### Type Utilities - [`StringKeyOf`](./src/lib/types.ts)
 
 Type helpers for improved type safety:
 

--- a/ng/practices-ng-dirty-guard/README.md
+++ b/ng/practices-ng-dirty-guard/README.md
@@ -24,7 +24,7 @@ npm install @nexplore/practices-ng-dirty-guard
 
 ## Features and Usage Examples
 
-### Navigation Guard - [`PuiDirtyGuardDirective`](./src/lib/directives/dirty-guard.directive.ts)
+### Navigation Guard - [`PuiGlobalDirtyGuardDirective`](./src/lib/directives/dirty-guard.directive.ts)
 
 Prevents accidental navigation when forms have unsaved changes. Apply the directive to your router-outlet:
 
@@ -47,7 +47,7 @@ bootstrapApplication(AppComponent, {
 Then, in your app component template:
 
 ```html
-<router-outlet puiDirtyGuard></router-outlet>
+<router-outlet puiGlobalDirtyGuard></router-outlet>
 ```
 
 ### Multiple Form Support
@@ -64,7 +64,7 @@ The dirty guard can track multiple forms in the same view, aggregating their dir
 </form>
 ```
 
-### Nested Routes Support - [`PuiNestedDirtyGuardDirective`](./src/lib/directives/nested-dirty-guard.directive.ts)
+### Nested Routes Support - [`PuiNestedDirtyGuardDirective`](./src/lib/directives/dirty-guard-nested.directive.ts)
 
 For applications using nested router-outlets, use the `PuiNestedDirtyGuardDirective` to ensure the dirty guard works properly in child routes:
 

--- a/ng/practices-ng-list-view-source/README.md
+++ b/ng/practices-ng-list-view-source/README.md
@@ -24,7 +24,7 @@ npm install @nexplore/practices-ng-list-view-source
 
 ## Features and Usage Examples
 
-### Fluent API Builders - [`tableViewSource`](./src/lib/table-view-source/table-view-source.factory.ts) & [`selectViewSource`](./src/lib/select-view-source/select-view-source.factory.ts)
+### Fluent API Builders - [`tableViewSource`](./src/lib/table-view-source-fluent-builder/index.ts) & [`selectViewSource`](./src/lib/select-view-source-fluent-builder/index.ts)
 
 The library provides two main view source builders with a fluent API for chainable configuration:
 

--- a/ng/practices-ui/README.md
+++ b/ng/practices-ui/README.md
@@ -16,7 +16,7 @@ npm install @nexplore/practices-ui
 
 ## Features and Usage Examples
 
-### Title Management - [`TitleService`](./src/lib/title/title.service.ts)
+### Title Management - [`TitleService`](./src/lib/services/title.service.ts)
 
 A service implementing Angular's `TitleStrategy` for managing the page title with breadcrumb support:
 
@@ -33,31 +33,35 @@ export class AppComponent {
     this._titleService.setTitle('My Application');
 
     // Set page title with breadcrumb
-    this._titleService.setBreadcrumbs([
-      { label: 'Home', route: '/' },
-      { label: 'Users', route: '/users' },
-      { label: 'User Details' }
-    ]);
+    this._titleService.setBreadcrumbTitle('User Details');
   }
 }
 ```
 
-### Translation Support - [`RewriteTranslateParser`](./src/lib/translate/rewrite-translate-parser.ts)
+### Translation Support - [`RewriteMissingTranslationHandler`](./src/lib/services/missing-translation.handler.ts)
 
-A custom `TranslateParser` which rewrites resource types for translations to work well with .NET resource file format:
+A custom `MissingTranslationHandler` which rewrites resource types for translations to work well with .NET resource file format:
 
 ```typescript
-import { provideTranslateParser } from '@nexplore/practices-ui';
+import { providePractices } from '@nexplore/practices-ui';
 import { TranslateModule } from '@ngx-translate/core';
 
 // In your app providers
-const providers = [provideTranslateParser()];
+const providers = [
+    providePractices({
+        rewriteResourceConfig: {
+            rewriteTypeConfig: {
+                Common: { rewriteTo: 'Shared' },
+            },
+        },
+    }),
+];
 
 // This allows using .NET resource format in translations
 // For example: "Common.Buttons_Save" instead of requiring "Common.Buttons.Save"
 ```
 
-### Component Lifecycle - [`DestroyService`](./src/lib/destroy/destroy.service.ts)
+### Component Lifecycle - [`DestroyService`](./src/lib/services/destroy.service.ts)
 
 A service for handling the `ngOnDestroy` lifecycle hook (deprecated in favor of Angular's `DestroyRef`):
 


### PR DESCRIPTION
🤖

## Description

This change syncs the Angular documentation to match the current repository layout. Practices.Ui installation paths were updated from the old `projects/*` location to the current `ng/*` location, stale Angular README links and API usage examples were corrected, and the obsolete `practices-ng-status-types` installation entry was removed. It is a documentation-only, repository-maintained update with no code, package, build configuration, or runtime behavior changes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## Verification

Automated checks and repository review are reflected in the current pull-request state. Detailed execution records are kept privately.

## Integration Instructions

N/A. Draft remains draft for maintainer review.