### PR TITLE
Sync main and port Tailwind radio tooltip support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,17 @@
-Fixes #
+## Description
 
-## Proposed Changes
+<_Include a description of the change and why this change was made._>
 
--
--
--
+- [ ] Impacts functionality?
+- [ ] Impacts security?
+- [ ] Breaking change?
+- [ ] Includes tests?
+- [ ] Includes documentation?
+
+## How This Was Tested
+
+<_Describe the test(s) that were run to verify the changes._>
+
+## Integration Instructions
+
+<_Describe how these changes should be integrated. Use N/A if nothing is required._>

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,49 @@
+# Canonical label definitions, synced to the repo by .github/workflows/label-sync.yaml.
+# Format: https://github.com/crazy-max/ghaction-github-labeler
+
+- name: impact:breaking-change
+  description: Requires integration attention
+  color: 'a54418'
+  aliases: []
+- name: impact:non-functional
+  description: Does not have a functional impact
+  color: 'c2e0c6'
+  aliases: []
+- name: impact:security
+  description: Has a security impact
+  color: '31df8c'
+  aliases: []
+- name: impact:testing
+  description: Affects testing
+  color: 'd4c5f9'
+  aliases: []
+
+- name: type:bug
+  description: Something isn't working
+  color: 'd73a4a'
+  aliases: []
+- name: type:documentation
+  description: Improvements or additions to documentation
+  color: '0075ca'
+  aliases: []
+- name: type:enhancement
+  description: New feature or pull request
+  color: 'a2eeef'
+  aliases: []
+- name: type:feature-request
+  description: A new feature proposal
+  color: 'a9dfbf'
+  aliases: []
+
+- name: semver:major
+  description: Pull requests that should increment the release major version
+  color: '000000'
+  aliases: []
+- name: semver:minor
+  description: Pull requests that should increment the release minor version
+  color: '000000'
+  aliases: []
+- name: semver:patch
+  description: Pull requests that should increment the release patch version
+  color: '000000'
+  aliases: []

--- a/.github/release-draft-config.yml
+++ b/.github/release-draft-config.yml
@@ -2,8 +2,8 @@
 # Categorizes merged PRs by the impact:* / type:* labels applied by the labeler.
 # Used by .github/workflows/release-drafter.yaml.
 
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 commitish: refs/heads/main
 filter-by-commitish: true
 
@@ -13,7 +13,7 @@ template: |
   $CHANGES
 
   Packages are hosted here: https://github.com/orgs/nexplore/packages?repo_name=nexplore-practices
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
 
 categories:
   - title: '⚠️ Breaking Changes'

--- a/.github/release-draft-config.yml
+++ b/.github/release-draft-config.yml
@@ -1,0 +1,91 @@
+# Minimal release-drafter config, inspired by OpenDevicePartnership/patina.
+# Categorizes merged PRs by the impact:* / type:* labels applied by the labeler.
+# Used by .github/workflows/release-drafter.yaml.
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+commitish: refs/heads/main
+filter-by-commitish: true
+
+template: |
+  # What's Changed
+
+  $CHANGES
+
+  Packages are hosted here: https://github.com/orgs/nexplore/packages?repo_name=nexplore-practices
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: '⚠️ Breaking Changes'
+    when:
+      labels:
+        - 'impact:breaking-change'
+  - title: '🚀 Features & ✨ Enhancements'
+    when:
+      labels:
+        - 'type:enhancement'
+        - 'type:feature-request'
+  - title: '🐛 Bug Fixes'
+    when:
+      labels:
+        - 'type:bug'
+  - title: '🔐 Security Impacting'
+    when:
+      labels:
+        - 'impact:security'
+  - title: '📖 Documentation'
+    when:
+      labels:
+        - 'type:documentation'
+  - title: '🧪 Tests'
+    when:
+      labels:
+        - 'impact:testing'
+
+  # type: version-resolver categories only affect the bump, not the changelog.
+  - type: version-resolver
+    semver-increment: major
+    when:
+      labels:
+        - 'semver:major'
+        - 'impact:breaking-change'
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      labels:
+        - 'semver:minor'
+        - 'type:enhancement'
+        - 'type:feature-request'
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      labels:
+        - 'semver:patch'
+        - 'impact:non-functional'
+        - 'type:bug'
+        - 'type:documentation'
+  # No `when` → default increment when nothing else matches (was `default: patch`).
+  - type: version-resolver
+    semver-increment: patch
+
+change-template: >-
+  <ul>
+    <li>
+      $TITLE @$AUTHOR (#$NUMBER)
+      <br>
+      <details>
+        <summary>Change Details</summary>
+        <blockquote>
+          <!-- Non-breaking space to have content if body is empty -->
+          &nbsp; $BODY
+        </blockquote>
+        <hr>
+      </details>
+    </li>
+  </ul>
+
+change-title-escapes: '\<*_&@' # Note: @ is added to disable mentions
+
+exclude-contributors:
+  - 'github-actions[bot]'
+  - 'dependabot[bot]'

--- a/.github/workflows/build.template.yml
+++ b/.github/workflows/build.template.yml
@@ -6,22 +6,22 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: dotnet/global.json
           dotnet-version: "8.x"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22.14.0"
           check-latest: true
       - run: chmod +x ./build.sh
       - run: ./build.sh BuildPackAll
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-output
           path: .nuke/temp/output

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -1,0 +1,28 @@
+name: "label-sync"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/label-sync.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    name: Sync labels
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: true
+          dry-run: false

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,32 @@
+name: "labeler"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PRs
+    runs-on: ubuntu-slim
+    steps:
+      - name: Apply Labels Based on PR File Paths
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          configuration-path: .github/workflows/labeler/branches.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: false # Whether or not to remove labels when matching files are reverted or no longer changed by the PR
+
+      - name: Label pull request from description
+        uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/workflows/labeler/regex-pull-requests.yml
+          enable-versioned-regex: 0
+          include-title: 0
+          include-body: 1
+          sync-labels: 1

--- a/.github/workflows/labeler/branches.yml
+++ b/.github/workflows/labeler/branches.yml
@@ -1,0 +1,23 @@
+# Configuration for labeler - https://github.com/actions/labeler
+"type:enhancement":
+  - head-branch:
+    - '^feat/'
+    - '^feat-'
+    - '^feature/'
+    - '^feature-'
+
+"type:bug":
+  - head-branch:
+    - '^fix/'
+    - '^fix-'
+    - '^bugfix/'
+    - '^bugfix-'
+    - '^bug/'
+    - '^bug-'
+
+"type:documentation":
+  - head-branch:
+    - '^docs/'
+    - '^docs-'
+    - '^doc/'
+    - '^doc-'

--- a/.github/workflows/labeler/regex-pull-requests.yml
+++ b/.github/workflows/labeler/regex-pull-requests.yml
@@ -1,0 +1,22 @@
+# Labels applied to pull requests based on the checkboxes in the PR description.
+# Used by .github/workflows/labeler.yaml via github/issue-labeler.
+# See: https://github.com/github/issue-labeler
+#
+# These labels drive the Release notes categories in .github/release.yml.
+#
+# Keep labels in ascending alphabetical order.
+
+impact:breaking-change:
+  - '\s*-\s*\[\s*[xX]\s*\] Breaking change\?'
+
+impact:non-functional:
+  - '\s*-\s*\[\s*(?![xX])\s*\] Impacts functionality\?'
+
+impact:security:
+  - '\s*-\s*\[\s*[xX]\s*\] Impacts security\?'
+
+impact:testing:
+  - '\s*-\s*\[\s*[xX]\s*\] Includes tests\?'
+
+type:documentation:
+  - '\s*-\s*\[\s*[xX]\s*\] Includes documentation\?'

--- a/.github/workflows/publish.template.yml
+++ b/.github/workflows/publish.template.yml
@@ -25,32 +25,32 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
 
       # Prepare .NET like ADO UseDotNet (global.json + explicit 8.x)
       - name: Setup .NET from global.json
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: dotnet/global.json
 
       - name: Setup .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: "8.x"
 
       # Prepare Node.js like ADO UseNode@1
       - name: Setup Node 22.14.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22.14.0"
           check-latest: true
 
       # Download the build artifact named 'build-output' from the prior job
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-output
           path: ${{ runner.temp }}/build-output

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,25 @@
+name: "release-drafter"
+
+# Maintains a draft GitHub release, updating its notes on every push to main
+# based on merged pull requests and their impact:* / type:* labels.
+# Config: .github/release-draft-config.yml
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  draft:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Update release draft
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          config-name: release-draft-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `practices-ui-ktbe` Added support for displaying custom left heading inside `PuibeExpansionPanelComponent` via a `heading-before` slot
+- `practices-ui-ktbe` Added `truncateHeading` input to `PuibeExpansionPanelComponent` to truncate long headings with ellipsis.
+
 ## [11.3.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.3.0) - 2026-06-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NOTE: CHANGELOG.md is deprecated
+
+After the release of v11.3.0, please see the [GitHub release notes](https://github.com/nexplore/nexplore-practices/releases) for the practices in order to view the most up-to-date changes.
+
 # Changelog
 
 All notable changes to this library will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Practices.Syncfusion.Excel` Updated Syncfusion.XlsIO.Net.Core to 33.2.15
 - `Practices.Syncfusion.Pdf` Updated Syncfusion.Pdf.Net.Core to 33.2.15
 
+### Added
+
+- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
+- `Practices.Core` Added TimeProviderClock
+- 
+### Changed
+
+-  _BREAKING_`Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
+
 ## [11.2.2](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.2) - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [11.2.3](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.3) - 2026-06-24
+
+### Changed
+
+- `Practices.*` Updated Microsoft.Extensions.\* dependencies
+- `Practices.Core` Updated Autofac to 9.3.0
+- `Practices.EntityFramework` Updated Microsoft.EntityFrameworkCore.\* dependencies
+- `Practices.Mail` Updated MailKit to 4.17.0
+- `Practices.Serilog` Updated Serilog.Settings.Configuration to 10.0.1
+- `Practices.Syncfusion.Excel` Updated Syncfusion.XlsIO.Net.Core to 33.2.15
+- `Practices.Syncfusion.Pdf` Updated Syncfusion.Pdf.Net.Core to 33.2.15
 
 ## [11.2.2](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.2) - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [11.2.3](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.3) - 2026-06-24
+## [11.3.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.3.0) - 2026-06-24
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `practices-ui-ktbe` Added support for displaying buttons inside the `PuibeTableColumnComponent` via a slot that displays next to the sorting button
 - `practices-ui-ktbe` Added support for displaying subcaptions inside `PuibeExpansionPanelComponent` via a slot that displays after the optional caption
+- `practices-ui-ktbe` Added `PuibeTooltipComponent` for simple display of helper text or context information.
+- `practices-ui-ktbe` Added input on `PuibeRadioButtonComponent` to display `description` as a tooltip.
 
 ### Changed
 

--- a/dotnet/src/Nexplore.Practices.Configuration/Nexplore.Practices.Configuration.csproj
+++ b/dotnet/src/Nexplore.Practices.Configuration/Nexplore.Practices.Configuration.csproj
@@ -11,11 +11,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/dotnet/src/Nexplore.Practices.Core/IClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/IClock.cs
@@ -5,11 +5,12 @@ namespace Nexplore.Practices.Core
     public interface IClock
     {
         DateTime Now { get; }
-
         DateTime UtcNow { get; }
 
-        DateTime Today { get; }
+        DateTimeOffset NowOffset { get; }
+        DateTimeOffset UtcNowOffset { get; }
 
-        DateTime UtcToday { get; }
+        DateOnly Today { get; }
+        DateOnly UtcToday { get; }
     }
 }

--- a/dotnet/src/Nexplore.Practices.Core/LocalComputerClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/LocalComputerClock.cs
@@ -5,11 +5,12 @@ namespace Nexplore.Practices.Core
     public class LocalComputerClock : IClock
     {
         public DateTime Now => DateTime.Now;
-
         public DateTime UtcNow => DateTime.UtcNow;
 
-        public DateTime Today => DateTime.Now.Date;
+        public DateTimeOffset NowOffset => DateTimeOffset.Now;
+        public DateTimeOffset UtcNowOffset => DateTimeOffset.UtcNow;
 
-        public DateTime UtcToday => DateTime.UtcNow.Date;
+        public DateOnly Today => DateOnly.FromDateTime(DateTime.Now);
+        public DateOnly UtcToday => DateOnly.FromDateTime(DateTime.UtcNow);
     }
 }

--- a/dotnet/src/Nexplore.Practices.Core/Nexplore.Practices.Core.csproj
+++ b/dotnet/src/Nexplore.Practices.Core/Nexplore.Practices.Core.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -26,8 +26,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="9.1.0" />
-        <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Autofac" Version="9.3.0" />
+        <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.1" />
     </ItemGroup>
 
 </Project>

--- a/dotnet/src/Nexplore.Practices.Core/Registry.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Registry.cs
@@ -1,5 +1,6 @@
 namespace Nexplore.Practices.Core
 {
+    using System;
     using Autofac;
     using Autofac.Core.Lifetime;
     using Nexplore.Practices.Core.Administration;
@@ -12,7 +13,8 @@ namespace Nexplore.Practices.Core
         protected override void Load(ContainerBuilder builder)
         {
             // Configure global services
-            builder.RegisterType<LocalComputerClock>().As<IClock>().SingleInstance();
+            builder.RegisterInstance(TimeProvider.System).As<TimeProvider>().SingleInstance();
+            builder.RegisterType<TimeProviderClock>().As<IClock>().SingleInstance();
             builder.RegisterType<EncryptionService>().As<IEncryptionService>().SingleInstance();
             builder.RegisterType<StaticSaltGenerationService>().As<ISaltGenerationService>().SingleInstance();
             builder.RegisterType<ValidationHelper>().As<IValidationHelper>().SingleInstance();

--- a/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
+++ b/dotnet/src/Nexplore.Practices.Core/TimeProviderClock.cs
@@ -1,0 +1,23 @@
+namespace Nexplore.Practices.Core
+{
+    using System;
+
+    public class TimeProviderClock : IClock
+    {
+        private readonly TimeProvider timeProvider;
+
+        public TimeProviderClock(TimeProvider timeProvider)
+        {
+            this.timeProvider = timeProvider;
+        }
+
+        public DateTime Now => DateTime.SpecifyKind(this.NowOffset.DateTime, DateTimeKind.Local);
+        public DateTime UtcNow => this.UtcNowOffset.UtcDateTime;
+
+        public DateTimeOffset NowOffset => this.timeProvider.GetLocalNow();
+        public DateTimeOffset UtcNowOffset => this.timeProvider.GetUtcNow();
+
+        public DateOnly Today => DateOnly.FromDateTime(this.Now);
+        public DateOnly UtcToday => DateOnly.FromDateTime(this.UtcNow);
+    }
+}

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Generators/DataSeedingService.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Generators/DataSeedingService.cs
@@ -51,7 +51,7 @@ namespace Nexplore.Practices.EntityFramework.Generators
                         }
                     }
 
-                    var now = this.clock.Now;
+                    var now = this.clock.NowOffset;
                     foreach (var migrationToApply in migrationsToApply)
                     {
                         migrationToApply.GeneratorsApplied = now;

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Nexplore.Practices.EntityFramework.csproj
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Nexplore.Practices.EntityFramework.csproj
@@ -15,9 +15,9 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/dotnet/src/Nexplore.Practices.Mail/Nexplore.Practices.Mail.csproj
+++ b/dotnet/src/Nexplore.Practices.Mail/Nexplore.Practices.Mail.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MailKit" Version="4.15.1" />
+        <PackageReference Include="MailKit" Version="4.17.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dotnet/src/Nexplore.Practices.Serilog/Nexplore.Practices.Serilog.csproj
+++ b/dotnet/src/Nexplore.Practices.Serilog/Nexplore.Practices.Serilog.csproj
@@ -13,7 +13,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
         <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+        <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/dotnet/src/Nexplore.Practices.Syncfusion.Excel/Nexplore.Practices.Syncfusion.Excel.csproj
+++ b/dotnet/src/Nexplore.Practices.Syncfusion.Excel/Nexplore.Practices.Syncfusion.Excel.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Syncfusion.XlsIO.Net.Core" Version="31.2.18" />
+        <PackageReference Include="Syncfusion.XlsIO.Net.Core" Version="33.2.15" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dotnet/src/Nexplore.Practices.Syncfusion.Pdf/Nexplore.Practices.Syncfusion.Pdf.csproj
+++ b/dotnet/src/Nexplore.Practices.Syncfusion.Pdf/Nexplore.Practices.Syncfusion.Pdf.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-        <PackageReference Include="Syncfusion.Pdf.Net.Core" Version="31.2.18" />
+        <PackageReference Include="Syncfusion.Pdf.Net.Core" Version="33.2.15" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dotnet/tests/Directory.Build.props
+++ b/dotnet/tests/Directory.Build.props
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/Domain/Test/TestRepositoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/Domain/Test/TestRepositoryTests.cs
@@ -36,16 +36,16 @@ namespace Nexplore.Practices.Tests.Integration.Domain.Test
         }
 
         [Test]
-        public void GetByIdAsync_WithNonExistingEntityId_ThrowsEntityNotFoundException()
+        public async Task GetByIdAsync_WithNonExistingEntityId_ThrowsEntityNotFoundException()
         {
             // Arrange
             using (var unitOfWork = this.unitOfWorkFactory.Begin())
             {
                 // Act
-                AsyncTestDelegate act = async () => await unitOfWork.Dependent.GetByIdAsync(Guid.NewGuid());
+                var act = async () => await unitOfWork.Dependent.GetByIdAsync(Guid.NewGuid());
 
                 // Assert
-                Assert.That(act, Throws.Exception.InstanceOf<EntityNotFoundException>());
+                await Assert.ThatAsync(act, Throws.Exception.InstanceOf<EntityNotFoundException>());
             }
         }
 

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/Mail/MailServiceTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/Mail/MailServiceTests.cs
@@ -1,6 +1,7 @@
 namespace Nexplore.Practices.Tests.Integration.Mail
 {
     using System.Threading;
+    using System.Threading.Tasks;
     using MailKit.Security;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
@@ -13,7 +14,7 @@ namespace Nexplore.Practices.Tests.Integration.Mail
     {
         [Test]
         [Ignore("Manual tests -> If you want to execute the test, verify the mail settings within the test first")]
-        public void SendEmail_WithFullConfiguration_SendsEmailAndStoresOnFilesystem()
+        public async Task SendEmail_WithFullConfiguration_SendsEmailAndStoresOnFilesystem()
         {
             // Arrange
             var mailOptions = Substitute.For<IOptions<MailOptions>>();
@@ -40,10 +41,10 @@ namespace Nexplore.Practices.Tests.Integration.Mail
             var service = new MailService(mailOptions, logger);
 
             // Act
-            AsyncTestDelegate act = async () => await service.SendMailAsync(subject, contentAsPlain, contentAsHtml, recipient, false, CancellationToken.None);
+            var act = async () => await service.SendMailAsync(subject, contentAsPlain, contentAsHtml, recipient, false, CancellationToken.None);
 
             // Assert
-            Assert.That(act, Throws.Nothing);
+            await Assert.ThatAsync(act, Throws.Nothing);
         }
     }
 }

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/Nexplore.Practices.Tests.Integration.csproj
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/Nexplore.Practices.Tests.Integration.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+      <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/Security/Cryptography/EncryptionServiceTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/Security/Cryptography/EncryptionServiceTests.cs
@@ -46,7 +46,7 @@ namespace Nexplore.Practices.Tests.Unit.Core.Security.Cryptography
             var encryptedData = service.EncryptDataAes(inputData, encryptPassword, out byte[] iv);
 
             // Act
-            TestDelegate act = () => service.DecryptDataAes(encryptedData, decryptPassword, iv);
+            Action act = () => service.DecryptDataAes(encryptedData, decryptPassword, iv);
 
             // Assert
             Assert.Throws<CryptographicException>(act);
@@ -71,7 +71,7 @@ namespace Nexplore.Practices.Tests.Unit.Core.Security.Cryptography
             var encryptedData = service1.EncryptDataAes(inputData, password, out byte[] iv);
 
             // Act
-            TestDelegate act = () => service2.DecryptDataAes(encryptedData, password, iv);
+            Action act = () => service2.DecryptDataAes(encryptedData, password, iv);
 
             // Assert
             Assert.Throws<CryptographicException>(act);
@@ -86,10 +86,10 @@ namespace Nexplore.Practices.Tests.Unit.Core.Security.Cryptography
 
             var service = new EncryptionService(new StaticSaltGenerationService());
 
-            var encryptedData = service.EncryptDataAes(inputData, password, out byte[] iv);
+            var encryptedData = service.EncryptDataAes(inputData, password, out byte[] _);
 
             // Act
-            TestDelegate act = () => service.DecryptDataAes(encryptedData, password, Array.Empty<byte>());
+            Action act = () => service.DecryptDataAes(encryptedData, password, Array.Empty<byte>());
 
             // Assert
             Assert.Throws<CryptographicException>(act);

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Core/TimeProviderClockTests.cs
@@ -2,16 +2,17 @@ namespace Nexplore.Practices.Tests.Unit.Core
 {
     using System;
     using Nexplore.Practices.Core;
+    using NSubstitute;
     using NUnit.Framework;
 
     [TestFixture]
-    public class LocalComputerClockTests
+    public class TimeProviderClockTests
     {
         [Test]
         public void Now_WithDefault_IsOfKindLocal()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.Now;
@@ -24,7 +25,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void UtcNow_WithDefault_IsOfKindUtc()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.UtcNow;
@@ -37,7 +38,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void Now_WithDefault_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.Now;
@@ -50,7 +51,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void UtcNow_WithDefault_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.UtcNow;
@@ -63,7 +64,7 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void NowOffset_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.NowOffset;
@@ -76,13 +77,36 @@ namespace Nexplore.Practices.Tests.Unit.Core
         public void UtcNowOffset_ContainsTimeInformation()
         {
             // Arrange
-            var clock = new LocalComputerClock();
+            var clock = new TimeProviderClock(TimeProvider.System);
 
             // Act
             var result = clock.UtcNowOffset;
 
             // Assert
             Assert.That(result.TimeOfDay, Is.Not.EqualTo(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Values_WithCustomLocalTimeZone_AreDerivedFromTimeProvider()
+        {
+            // Arrange
+            var utcNow = new DateTimeOffset(2024, 1, 1, 23, 30, 0, TimeSpan.Zero);
+            var localTimeZone = TimeZoneInfo.CreateCustomTimeZone("Test/UTC+02", TimeSpan.FromHours(2), "Test/UTC+02", "Test/UTC+02");
+            var timeProvider = NSubstitute.Substitute.For<TimeProvider>();
+            timeProvider.GetUtcNow().Returns(utcNow);
+            timeProvider.LocalTimeZone.Returns(localTimeZone);
+            var clock = new TimeProviderClock(timeProvider);
+
+            // Act & Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(clock.UtcNowOffset, Is.EqualTo(utcNow));
+                Assert.That(clock.NowOffset, Is.EqualTo(new DateTimeOffset(2024, 1, 2, 1, 30, 0, TimeSpan.FromHours(2))));
+                Assert.That(clock.UtcNow, Is.EqualTo(new DateTime(2024, 1, 1, 23, 30, 0, DateTimeKind.Utc)));
+                Assert.That(clock.Now, Is.EqualTo(new DateTime(2024, 1, 2, 1, 30, 0, DateTimeKind.Local)));
+                Assert.That(clock.UtcToday, Is.EqualTo(new DateOnly(2024, 1, 1)));
+                Assert.That(clock.Today, Is.EqualTo(new DateOnly(2024, 1, 2)));
+            });
         }
     }
 }

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Generators/GeneratorDependencyNodeTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Generators/GeneratorDependencyNodeTests.cs
@@ -101,7 +101,7 @@ namespace Nexplore.Practices.Tests.Unit.EntityFramework.Generators
         }
 
         [Test]
-        public void Visit_WithSelfReferencedGenerator_ThrowsException()
+        public async Task Visit_WithSelfReferencedGenerator_ThrowsException()
         {
             // Arrange
             var scope = this.container.BeginLifetimeScope();
@@ -109,14 +109,14 @@ namespace Nexplore.Practices.Tests.Unit.EntityFramework.Generators
             var node = new GeneratorDependencyNode<TestSelfReferenceGenerator>(scope);
 
             // Act
-            AsyncTestDelegate act = async () => await node.VisitAsync(visitor, CancellationToken.None);
+            var act = async () => await node.VisitAsync(visitor, CancellationToken.None);
 
             // Act
-            Assert.That(act, Throws.Exception.TypeOf<InvalidOperationException>());
+            await Assert.ThatAsync(act, Throws.Exception.TypeOf<InvalidOperationException>());
         }
 
         [Test]
-        public void Visit_WithCycleDependent_ThrowsException()
+        public async Task Visit_WithCycleDependent_ThrowsException()
         {
             // Arrange
             var scope = this.container.BeginLifetimeScope();
@@ -124,10 +124,10 @@ namespace Nexplore.Practices.Tests.Unit.EntityFramework.Generators
             var node = new GeneratorDependencyNode<TestCycleGenerator1>(scope);
 
             // Act
-            AsyncTestDelegate act = async () => await node.VisitAsync(visitor, CancellationToken.None);
+            var act = async () => await node.VisitAsync(visitor, CancellationToken.None);
 
             // Act
-            Assert.That(act, Throws.Exception.TypeOf<InvalidOperationException>());
+            await Assert.ThatAsync(act, Throws.Exception.TypeOf<InvalidOperationException>());
         }
 
         [Test]

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/File/MimeTypeMappingTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/File/MimeTypeMappingTests.cs
@@ -40,7 +40,7 @@ namespace Nexplore.Practices.Tests.Unit.File
         public void GetContentTypeFromFilename_WithoutEmptyFilename_ShouldThrowException()
         {
             // Act
-            TestDelegate act = () => this.mimeTypeMapping.GetContentTypeFromFileName(string.Empty);
+            var act = () => this.mimeTypeMapping.GetContentTypeFromFileName(string.Empty);
 
             // Assert
             Assert.That(act, Throws.Exception.InstanceOf<ArgumentException>());
@@ -50,7 +50,7 @@ namespace Nexplore.Practices.Tests.Unit.File
         public void GetContentTypeFromFilename_WithoutNullFilename_ShouldThrowException()
         {
             // Act
-            TestDelegate act = () => this.mimeTypeMapping.GetContentTypeFromFileName(null);
+            var act = () => this.mimeTypeMapping.GetContentTypeFromFileName(null);
 
             // Assert
             Assert.That(act, Throws.Exception.InstanceOf<ArgumentNullException>());
@@ -61,7 +61,7 @@ namespace Nexplore.Practices.Tests.Unit.File
             yield return new TestCaseData("unknown").Returns(MimeTypeMapping.DEFAULT_MIME_TYPE);
             yield return new TestCaseData("unknown.extension").Returns(MimeTypeMapping.DEFAULT_MIME_TYPE);
             yield return new TestCaseData("pdf").Returns(MimeTypeMapping.DEFAULT_MIME_TYPE);
-            yield return new TestCaseData("with.muliple.points.pdf").Returns("application/pdf");
+            yield return new TestCaseData("with.multiple.points.pdf").Returns("application/pdf");
             yield return new TestCaseData("file.test").Returns(TEST_MIME_TYPE);
         }
     }

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Web/Localization/ClientLocalizationServiceTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Web/Localization/ClientLocalizationServiceTests.cs
@@ -98,7 +98,7 @@ namespace Nexplore.Practices.Tests.Unit.Web.Localization
             this.localizationOptionsMock.Value.Returns(localizationOptions);
 
             // Act
-            TestDelegate act = () => this.clientLocalizationService.GetLocalizationsForCulture(CultureInfo.InvariantCulture);
+            var act = () => this.clientLocalizationService.GetLocalizationsForCulture(CultureInfo.InvariantCulture);
 
             // Assert
             Assert.That(act, Throws.ArgumentException);

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.html
@@ -12,25 +12,43 @@
                     'p-3': compact,
                     'bg-dark-sand aria-expanded:bg-sand hover:bg-sand-hover focus:bg-sand-hover aria-expanded:hover:bg-sand-hover aria-expanded:focus:bg-sand-hover':
                         isSand,
-                    'bg-sand aria-expanded:bg-light-sand hover:bg-sand focus:bg-sand aria-expanded:hover:bg-sand aria-expanded:focus:bg-sand': 
+                    'bg-sand aria-expanded:bg-light-sand hover:bg-sand focus:bg-sand aria-expanded:hover:bg-sand aria-expanded:focus:bg-sand':
                         isLightSand,
                     'hover:bg-very-light-gray focus:bg-very-light-gray aria-expanded:hover:bg-very-light-gray aria-expanded:focus:bg-very-light-gray bg-white aria-expanded:bg-white':
                         isWhite,
                     'hover:bg-red-hover focus:bg-red-hover aria-expanded:hover:bg-red-hover aria-expanded:focus:bg-red-hover bg-red text-white':
-                        isRed,
+                        isRed
                 }"
                 (click)="toggle(accordionItem)"
             >
                 <span class="sr-only">{{ 'Practices.Labels_ExpansionPanel' | translate }}</span>
-                <div class="mr-6 flex flex-col items-start">
-                    <div class="flex items-center gap-4">
-                        <p *ngIf="heading" [ngClass]="compact ? 'text-base' : 'text-h4'">{{ heading }}</p>
-                        <ng-content select="[slot='heading-after']"></ng-content>
+                <div class="mr-6 flex min-w-0 flex-1 items-stretch">
+                    <div class="flex shrink-0 items-center self-stretch">
+                        <ng-content select="[slot='heading-before']"></ng-content>
                     </div>
-                    <p class="mt-1" *ngIf="caption">{{ caption }}</p>
-                    <ng-content select="[slot='caption-after']"></ng-content>
+                    <div class="flex min-w-0 flex-1 flex-col items-start">
+                        <div class="flex min-w-0 max-w-full items-center gap-4">
+                            <p
+                                #headingText
+                                *ngIf="heading"
+                                class="min-w-0"
+                                [ngClass]="[
+                                    compact ? 'text-base' : 'text-h4',
+                                    truncateHeading ? 'truncate' : 'whitespace-normal'
+                                ]"
+                                [attr.title]="truncateHeading ? heading : null"
+                            >
+                                {{ heading }}
+                            </p>
+
+                            <span #headingAfterInlineHost class="inline-flex shrink-0 items-center"></span>
+                        </div>
+                        <p class="mt-1" *ngIf="caption">{{ caption }}</p>
+                        <ng-content select="[slot='caption-after']"></ng-content>
+                    </div>
                 </div>
-                <div class="flex items-center gap-4">
+                <div class="flex shrink-0 items-center gap-4">
+                    <span #headingAfterActionHost class="inline-flex shrink-0 items-center"></span>
                     <ng-content select="[slot='arrow-before']"></ng-content>
                     <puibe-icon-arrow
                         direction="down"
@@ -38,6 +56,13 @@
                         class="rotate-0 transition-all duration-[250ms] ease-in-out group-hover:-rotate-90 group-aria-expanded:-rotate-180 group-aria-expanded:group-hover:-rotate-90"
                     ></puibe-icon-arrow>
                 </div>
+
+                <span
+                    #headingAfterWrapper
+                    class="inline-flex shrink-0 items-center whitespace-nowrap text-current [&_*]:text-current"
+                >
+                    <ng-content select="[slot='heading-after']"></ng-content>
+                </span>
             </button>
         </div>
         <div

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.spec.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.spec.ts
@@ -1,0 +1,116 @@
+import '@angular/compiler';
+import { ChangeDetectorRef, ElementRef } from '@angular/core';
+import { PuibeExpansionPanelComponent } from './expansion-panel.component';
+
+describe('PuibeExpansionPanelComponent', () => {
+    let component: PuibeExpansionPanelComponent;
+    let markForCheck: jest.Mock;
+
+    beforeEach(() => {
+        markForCheck = jest.fn();
+        component = new PuibeExpansionPanelComponent(new ElementRef(document.createElement('div')), {
+            markForCheck,
+        } as unknown as ChangeDetectorRef);
+    });
+
+    it('moves the heading after into the action area and reserves its inline width', () => {
+        const { heading, headingAfterInlineHost, headingAfterActionHost, headingAfterWrapper, setHeadingHeight } =
+            setupHeadingAfterLayout();
+
+        setHeadingHeight(48);
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 42);
+
+        component.headingText = { nativeElement: heading } as ElementRef<HTMLElement>;
+        component.headingAfterWrapper = { nativeElement: headingAfterWrapper } as ElementRef<HTMLElement>;
+        component.headingAfterInlineHost = { nativeElement: headingAfterInlineHost } as ElementRef<HTMLElement>;
+        component.headingAfterActionHost = { nativeElement: headingAfterActionHost } as ElementRef<HTMLElement>;
+
+        jest.spyOn(window, 'getComputedStyle').mockReturnValue({ lineHeight: '24px' } as CSSStyleDeclaration);
+
+        component['updateHeadingAfterPosition']();
+
+        expect(headingAfterActionHost.contains(headingAfterWrapper)).toBe(true);
+        expect(headingAfterInlineHost.style.minWidth).toBe('42px');
+        expect(markForCheck).toHaveBeenCalledTimes(1);
+    });
+
+    it('moves the heading after back inline and clears the reserved width when the heading no longer wraps', () => {
+        const { heading, headingAfterInlineHost, headingAfterActionHost, headingAfterWrapper, setHeadingHeight } =
+            setupHeadingAfterLayout();
+
+        setHeadingHeight(48);
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 42);
+
+        component.headingText = { nativeElement: heading } as ElementRef<HTMLElement>;
+        component.headingAfterWrapper = { nativeElement: headingAfterWrapper } as ElementRef<HTMLElement>;
+        component.headingAfterInlineHost = { nativeElement: headingAfterInlineHost } as ElementRef<HTMLElement>;
+        component.headingAfterActionHost = { nativeElement: headingAfterActionHost } as ElementRef<HTMLElement>;
+
+        jest.spyOn(window, 'getComputedStyle').mockReturnValue({ lineHeight: '24px' } as CSSStyleDeclaration);
+
+        component['updateHeadingAfterPosition']();
+        setHeadingHeight(24);
+
+        component['updateHeadingAfterPosition']();
+
+        expect(headingAfterInlineHost.contains(headingAfterWrapper)).toBe(true);
+        expect(headingAfterInlineHost.style.minWidth).toBe('');
+        expect(markForCheck).toHaveBeenCalledTimes(2);
+    });
+
+    it('updates the reserved inline width when the content changes while still wrapped', () => {
+        const { heading, headingAfterInlineHost, headingAfterActionHost, headingAfterWrapper, setHeadingHeight } =
+            setupHeadingAfterLayout();
+
+        setHeadingHeight(48);
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 42);
+
+        component.headingText = { nativeElement: heading } as ElementRef<HTMLElement>;
+        component.headingAfterWrapper = { nativeElement: headingAfterWrapper } as ElementRef<HTMLElement>;
+        component.headingAfterInlineHost = { nativeElement: headingAfterInlineHost } as ElementRef<HTMLElement>;
+        component.headingAfterActionHost = { nativeElement: headingAfterActionHost } as ElementRef<HTMLElement>;
+
+        jest.spyOn(window, 'getComputedStyle').mockReturnValue({ lineHeight: '24px' } as CSSStyleDeclaration);
+
+        component['updateHeadingAfterPosition']();
+        setHeadingAfterWrapperWidth(headingAfterWrapper, 64);
+
+        component['updateHeadingAfterPosition']();
+
+        expect(headingAfterActionHost.contains(headingAfterWrapper)).toBe(true);
+        expect(headingAfterInlineHost.style.minWidth).toBe('64px');
+        expect(markForCheck).toHaveBeenCalledTimes(1);
+    });
+});
+
+function setupHeadingAfterLayout() {
+    let headingHeight = 24;
+    const heading = document.createElement('p');
+    Object.defineProperty(heading, 'clientHeight', {
+        configurable: true,
+        get: () => headingHeight,
+    });
+
+    const headingAfterInlineHost = document.createElement('span');
+    const headingAfterActionHost = document.createElement('span');
+    const headingAfterWrapper = document.createElement('span');
+
+    headingAfterInlineHost.appendChild(headingAfterWrapper);
+
+    return {
+        heading,
+        headingAfterInlineHost,
+        headingAfterActionHost,
+        headingAfterWrapper,
+        setHeadingHeight(height: number) {
+            headingHeight = height;
+        },
+    };
+}
+
+function setHeadingAfterWrapperWidth(element: HTMLElement, width: number) {
+    Object.defineProperty(element, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ width }),
+    });
+}

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.component.ts
@@ -1,7 +1,19 @@
 import { animate, AnimationTriggerMetadata, state, style, transition, trigger } from '@angular/animations';
 import { CdkAccordionItem, CdkAccordionModule } from '@angular/cdk/accordion';
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, OnInit, ViewChild } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    HostBinding,
+    Input,
+    OnChanges,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { PuibeIconArrowComponent } from '../icons/icon-arrow.component';
 import { isElementVisibleInVerticalScrollView } from '../util/utils';
@@ -9,6 +21,13 @@ import { isElementVisibleInVerticalScrollView } from '../util/utils';
 let nextUniqueId = 0;
 
 const ANIMATION_DURATION_MS = 225;
+
+type HeadingAfterLayout = {
+    heading: HTMLElement;
+    headingAfterWrapper: HTMLElement;
+    headingAfterInlineHost: HTMLElement;
+    headingAfterActionHost: HTMLElement;
+};
 
 const bodyExpansionAnimation: AnimationTriggerMetadata = trigger('bodyExpansion', [
     state(
@@ -38,7 +57,7 @@ const bodyExpansionAnimation: AnimationTriggerMetadata = trigger('bodyExpansion'
     imports: [CdkAccordionModule, PuibeIconArrowComponent, CommonModule, TranslateModule],
     animations: [bodyExpansionAnimation],
 })
-export class PuibeExpansionPanelComponent implements OnInit {
+export class PuibeExpansionPanelComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
     @HostBinding('class')
     className = 'block';
 
@@ -47,6 +66,18 @@ export class PuibeExpansionPanelComponent implements OnInit {
 
     @ViewChild('content', { static: true })
     contentRef: ElementRef<HTMLElement>;
+
+    @ViewChild('headingText')
+    headingText?: ElementRef<HTMLElement>;
+
+    @ViewChild('headingAfterWrapper')
+    headingAfterWrapper?: ElementRef<HTMLElement>;
+
+    @ViewChild('headingAfterInlineHost')
+    headingAfterInlineHost?: ElementRef<HTMLElement>;
+
+    @ViewChild('headingAfterActionHost')
+    headingAfterActionHost?: ElementRef<HTMLElement>;
 
     private _id: string = (nextUniqueId++).toString();
     @Input()
@@ -96,6 +127,12 @@ export class PuibeExpansionPanelComponent implements OnInit {
     @Input()
     enableContentScroll = false;
 
+    /**
+     * If `true`, truncates the heading text with ellipsis when it overflows.
+     */
+    @Input()
+    truncateHeading = false;
+
     get isSand(): boolean {
         return this.variant === 'sand';
     }
@@ -116,10 +153,33 @@ export class PuibeExpansionPanelComponent implements OnInit {
     // `isInitiallyCollapsed` is only true, if `isExpanded` is initially false. As soon `isExpanded` gets changed, `isInitiallyCollapsed` gets reset to false.
     isInitiallyCollapsed?: boolean = undefined;
 
-    constructor(private elRef: ElementRef<HTMLElement>) {}
+    private resizeObserver?: ResizeObserver;
+
+    constructor(private elRef: ElementRef<HTMLElement>, private cdr: ChangeDetectorRef) {}
 
     ngOnInit(): void {
         this.isInitiallyCollapsed = !this.isExpanded;
+    }
+
+    ngAfterViewInit(): void {
+        this.resizeObserver = new ResizeObserver(() => this.updateHeadingAfterPosition());
+
+        queueMicrotask(() => {
+            if (this.headingText?.nativeElement) {
+                this.resizeObserver?.observe(this.headingText.nativeElement);
+            }
+
+            this.resizeObserver?.observe(this.elRef.nativeElement);
+            this.updateHeadingAfterPosition();
+        });
+    }
+
+    ngOnChanges(): void {
+        queueMicrotask(() => this.updateHeadingAfterPosition());
+    }
+
+    ngOnDestroy(): void {
+        this.resizeObserver?.disconnect();
     }
 
     _getExpandedState(): 'expanded' | 'collapsed' {
@@ -149,5 +209,77 @@ export class PuibeExpansionPanelComponent implements OnInit {
         setTimeout(() => {
             this.elRef.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }, timeout);
+    }
+
+    private updateHeadingAfterPosition(): void {
+        const layout = this.getHeadingAfterLayout();
+
+        if (!layout) {
+            return;
+        }
+
+        const shouldRenderInActionArea = this.shouldRenderHeadingAfterInActionArea(layout.heading);
+        const targetHost = shouldRenderInActionArea ? layout.headingAfterActionHost : layout.headingAfterInlineHost;
+
+        this.updateInlineHostReservation(
+            layout.headingAfterInlineHost,
+            layout.headingAfterWrapper,
+            shouldRenderInActionArea
+        );
+        this.moveHeadingAfterWrapper(layout.headingAfterWrapper, targetHost);
+    }
+
+    private getHeadingAfterLayout(): HeadingAfterLayout | undefined {
+        const heading = this.headingText?.nativeElement;
+        const headingAfterWrapper = this.headingAfterWrapper?.nativeElement;
+        const headingAfterInlineHost = this.headingAfterInlineHost?.nativeElement;
+        const headingAfterActionHost = this.headingAfterActionHost?.nativeElement;
+
+        if (!heading || !headingAfterWrapper || !headingAfterInlineHost || !headingAfterActionHost) {
+            return undefined;
+        }
+
+        return {
+            heading,
+            headingAfterWrapper,
+            headingAfterInlineHost,
+            headingAfterActionHost,
+        };
+    }
+
+    private shouldRenderHeadingAfterInActionArea(heading: HTMLElement): boolean {
+        if (this.truncateHeading) {
+            return false;
+        }
+
+        // If heading wraps to more than one line (> 1.5× line height),
+        // render the heading-after content in the action area (left to arrow-before).
+        const computedLineHeight = parseFloat(getComputedStyle(heading).lineHeight);
+        return heading.clientHeight > computedLineHeight * 1.5;
+    }
+
+    private updateInlineHostReservation(
+        inlineHost: HTMLElement,
+        headingAfterWrapper: HTMLElement,
+        shouldReserveInlineSpace: boolean
+    ): void {
+        // Reserve inline space for the heading-after wrapper to prevent DOM oscillation:
+        // When moving the wrapper to the action area, we keep the inline area width reserved
+        // so the heading doesn't reflow and become single-line again, which would cause
+        // the wrapper to move back inline on the next resize, creating a flicker loop.
+        if (shouldReserveInlineSpace) {
+            const wrapperWidth = Math.ceil(headingAfterWrapper.getBoundingClientRect().width);
+            inlineHost.style.minWidth = `${wrapperWidth}px`;
+        } else {
+            inlineHost.style.minWidth = '';
+        }
+    }
+
+    private moveHeadingAfterWrapper(headingAfterWrapper: HTMLElement, targetHost: HTMLElement): void {
+        // Only move if the DOM parent actually changed to avoid unnecessary reflows.
+        if (headingAfterWrapper.parentElement !== targetHost) {
+            targetHost.appendChild(headingAfterWrapper);
+            this.cdr.markForCheck();
+        }
     }
 }

--- a/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/expansion-panel/expansion-panel.stories.ts
@@ -1,20 +1,23 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { PuibeExpansionPanelComponent } from './expansion-panel.component';
 import { PuibeIconEditComponent } from '../icons/icon-edit.component';
 import { PuibeIconInvalidComponent } from '../icons/icon-invalid.component';
+import { PuibeExpansionPanelComponent } from './expansion-panel.component';
 
 type Args = {
     heading?: string;
     headingLevel?: number;
     caption?: string;
+    useHeadingBefore?: boolean;
     useHeadingAfter?: boolean;
+    useCaptionAfter?: boolean;
     useArrowBefore?: boolean;
     isExpanded?: boolean;
     addItemPadding?: boolean;
     variant?: 'sand' | 'white' | 'red';
     disableScrollIntoView?: boolean;
     enableContentScroll?: boolean;
+    truncateHeading?: boolean;
 };
 
 const meta: Meta<Args> = {
@@ -26,10 +29,14 @@ const meta: Meta<Args> = {
         headingLevel: { type: 'number', defaultValue: 2 },
         useHeadingAfter: { type: 'boolean', defaultValue: false },
         useArrowBefore: { type: 'boolean', defaultValue: false },
+        useHeadingBefore: { type: 'boolean', defaultValue: false },
+        useCaptionAfter: { type: 'boolean', defaultValue: false },
         isExpanded: { type: 'boolean', defaultValue: false },
         addItemPadding: { type: 'boolean', defaultValue: true },
         enableContentScroll: { type: 'boolean', defaultValue: false },
         variant: { type: { name: 'enum', value: ['sand', 'white', 'red'] }, defaultValue: 'sand' },
+        truncateHeading: { type: 'boolean', defaultValue: false },
+        caption: { type: 'string' },
     },
     decorators: [
         moduleMetadata({
@@ -46,13 +53,19 @@ const meta: Meta<Args> = {
             ...args,
         },
         template: `
-        <puibe-expansion-panel class="w-3/4" [heading]="heading" [disableScrollIntoView]="disableScrollIntoView" [enableContentScroll]="enableContentScroll" [headingLevel]="headingLevel" [caption]="caption" [isExpanded]="isExpanded" [variant]="variant" [addItemPadding]="addItemPadding">
+        <puibe-expansion-panel class="w-3/4" [heading]="heading" [disableScrollIntoView]="disableScrollIntoView" [enableContentScroll]="enableContentScroll" [headingLevel]="headingLevel" [caption]="caption" [isExpanded]="isExpanded" [variant]="variant" [addItemPadding]="addItemPadding" [truncateHeading]="truncateHeading">
             <span>Test Content</span>
+            ${
+                args.useHeadingBefore
+                    ? '<puibe-icon-invalid slot="heading-before" size="m" class="mr-4"></puibe-icon-invalid>'
+                    : ''
+            }
             ${
                 args.useHeadingAfter
                     ? '<a href="http://www.google.ch" target="_blank" slot="heading-after"><puibe-icon-edit class="w-[1.5em] inline-block translate-y-1"></puibe-icon-edit></a>'
                     : ''
             }
+            ${args.useCaptionAfter ? '<span slot="caption-after">Caption After</span>' : ''}
             ${
                 args.useArrowBefore
                     ? '<puibe-icon-invalid class="h-6 w-6 block" slot="arrow-before"></puibe-icon-invalid>'
@@ -164,4 +177,75 @@ export const ScrollIntoView: Story = {
         </div>
         `,
     }),
+};
+
+export const WithAllSlots: Story = {
+    args: {
+        heading: 'Heading',
+        caption: 'A small caption',
+        useHeadingBefore: true,
+        useHeadingAfter: true,
+        useCaptionAfter: true,
+        useArrowBefore: true,
+        isExpanded: false,
+        addItemPadding: true,
+        variant: 'white',
+        disableScrollIntoView: false,
+        enableContentScroll: false,
+        truncateHeading: false,
+    },
+};
+
+export const WithAllSlotNamesVisible: Story = {
+    args: {
+        heading: 'Heading',
+        isExpanded: false,
+        headingLevel: 2,
+        variant: 'white',
+        addItemPadding: false,
+        truncateHeading: false,
+        caption: 'Caption',
+    },
+    render: (args) => ({
+        props: { ...args },
+        template: `
+            <puibe-expansion-panel
+                class="w-full max-w-[800px]"
+                [heading]="heading"
+                [headingLevel]="headingLevel"
+                [isExpanded]="isExpanded"
+                [variant]="variant"
+                [addItemPadding]="addItemPadding"
+                [truncateHeading]="truncateHeading"
+                [caption]="caption"
+            >
+                <span slot="heading-before" class="mr-4">heading-before</span>
+                <span slot="heading-after">heading-after</span>
+                <span slot="caption-after">caption-after</span>
+                <span slot="arrow-before" class="whitespace-nowrap">arrow-before</span>
+
+                <div>Inhalt des Expansion Panels</div>
+            </puibe-expansion-panel>
+        `,
+    }),
+};
+
+export const WithLongHeadingWithoutTruncation: Story = {
+    args: {
+        ...WithAllSlots.args,
+        heading:
+            'Invoice-File-Name-This-Is-An-Extremely-Long-Heading-To-Verify-That-The-Expansion-Panel-Title-Can-Wrap-Correctly.pdf',
+        truncateHeading: false,
+    },
+    render: WithAllSlots.render,
+};
+
+export const WithLongHeadingAndTruncation: Story = {
+    args: {
+        ...WithAllSlots.args,
+        heading:
+            'Invoice-File-Name-This-Is-An-Extremely-Long-Heading-To-Verify-That-The-Expansion-Panel-Title-Is-Truncated-Correctly.pdf',
+        truncateHeading: true,
+    },
+    render: WithAllSlots.render,
 };

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button-group.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button-group.stories.ts
@@ -17,6 +17,7 @@ type Args = {
     hideGroupBorders?: boolean;
     hideOptional?: boolean;
     legendAsLabel?: boolean;
+    descriptionAsTooltip?: boolean;
     gapVariant?: 'default' | 'large';
     asyncValidator?: boolean;
     readonly?: boolean;
@@ -45,6 +46,7 @@ const meta: Meta<Args> = {
         hideGroupBorders: { type: 'boolean', defaultValue: false },
         hideOptional: { type: 'boolean', defaultValue: false },
         legendAsLabel: { type: 'boolean', defaultValue: false },
+        descriptionAsTooltip: { type: 'boolean', defaultValue: false },
         asyncValidator: { type: 'boolean', defaultValue: false },
         readonly: { type: 'boolean', defaultValue: false },
         useSmallTextForReadonlyLabel: { type: 'boolean', defaultValue: false },
@@ -69,7 +71,7 @@ const meta: Meta<Args> = {
         template: `
         <div [formGroup]="formGroup" class="w-full"  [puibeReadonly]="readonly">
             <puibe-radio-button-group class="w-full" [useSmallTextForReadonlyLabel]="useSmallTextForReadonlyLabel" [legend]="legend" [attr.name]="name" [hint]="hint" formControlName="radio" [displayInline]="displayInline" [hideGroupBorders]="hideGroupBorders" [gapVariant]="gapVariant" [hideOptional]="hideOptional" [legendAsLabel]="legendAsLabel" [readonlyEmptyValuePlaceholder]="readonlyEmptyValuePlaceholder">
-                <puibe-radio-button [value]="value.id" [label]="value.name" [description]="value.description" *ngFor="let value of values; index as i"></puibe-radio-button>
+                <puibe-radio-button [value]="value.id" [label]="value.name" [description]="value.description" [descriptionAsTooltip]="descriptionAsTooltip" *ngFor="let value of values; index as i"></puibe-radio-button>
             </puibe-radio-button-group>
         </div>`,
     }),
@@ -266,19 +268,18 @@ export const AsyncValidatorRadioButtonGroup: Story = {
 export const RadioButtonGroupWithDescription: Story = {
     args: {
         legend: 'Label',
-        name: null,
-        hint: null,
         values: [
             { id: 1, name: 'Option 1', description: 'Beschreibungstext aus den Stammdaten' },
-            { id: 2, name: 'Option 2 mit Zusatz Text', description: 'Beschreibungstext aus den Stammdaten' },
+            {
+                id: 2,
+                name: 'Option 2 mit Zusatz Text',
+                description: 'Beschreibungstext aus den Stammdaten. Sehr langer Text, der dann mal umbrechen sollte.',
+            },
             { id: 3, name: 'Option 3', description: 'Beschreibungstext aus den Stammdaten' },
         ],
-        defaultValue: null,
-        required: false,
-        disabled: false,
         displayInline: false,
+        descriptionAsTooltip: false,
         gapVariant: 'large',
-        asyncValidator: false,
     },
 };
 

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.html
@@ -34,8 +34,16 @@
             ></div>
         </div>
     </div>
-    <div class="flex flex-col">
+    <div>
         {{ label }}
-        <span class="text-very-small" *ngIf="description">{{ description }}</span>
+        @if(description) {
+            @if(descriptionAsTooltip) {
+                <puibe-tooltip-button class="ml-1">
+                    <p class="text-small">{{ description }}</p>
+                </puibe-tooltip-button>
+            } @else {
+                <span class="text-very-small block">{{ description }}</span>
+            } 
+        }
     </div>
 </label>

--- a/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/radio-button/radio-button.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { PuiFormFieldService } from '@nexplore/practices-ng-forms';
 import { map } from 'rxjs';
+import { PuibeTooltipButtonComponent } from '../tooltip/tooltip.component';
 import { RadioButtonGroupService } from './radio-button-group.service';
 
 let nextUniqueId = 0;
@@ -12,7 +13,7 @@ let nextUniqueId = 0;
     selector: 'puibe-radio-button',
     templateUrl: './radio-button.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgClass, ReactiveFormsModule, AsyncPipe, NgIf],
+    imports: [NgClass, ReactiveFormsModule, AsyncPipe, NgIf, PuibeTooltipButtonComponent],
 })
 export class PuibeRadioButtonComponent {
     @Input()
@@ -23,6 +24,9 @@ export class PuibeRadioButtonComponent {
 
     @Input()
     description: string;
+
+    @Input()
+    descriptionAsTooltip = false;
 
     uniqueId = `radio-button-${nextUniqueId++}`;
 

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip-icon.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip-icon.component.ts
@@ -1,0 +1,32 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+    standalone: true,
+    selector: 'puibe-tooltip-icon',
+    template: `<svg
+        [class]="class"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        version="1.1"
+        x="0px"
+        y="0px"
+        width="14px"
+        height="24px"
+        viewBox="0 0 14 24"
+        enable-background="new 0 0 14 24"
+        xml:space="preserve"
+    >
+        <polygon
+            fill="white"
+            stroke="#000000"
+            stroke-width="1"
+            stroke-miterlimit="10"
+            points="0,12 7,0   14,12 7,24 "
+        />
+        <rect x="0" y="0" width="14" height="12" fill="white" />
+    </svg>`,
+})
+export class PuibeTooltipIconComponent {
+    @HostBinding('class') class = '';
+}
+

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
@@ -1,0 +1,25 @@
+<button
+    cdkOverlayOrigin
+    class="text-small leading-ktbe-small select-none rounded-full border bg-white px-[5px] py-0 font-bold transition-all duration-200 ease-in-out hover:scale-[1.2]"
+    (click)="toggle()"
+    [attr.aria-describedby]="tooltipId"
+    [attr.aria-label]="'Shared.ClickForMoreInfo' | translate"
+>
+    ?
+</button>
+
+<ng-template>
+    <div
+        role="tooltip"
+        [id]="tooltipId"
+        class="flex items-center justify-center"
+        [class]="signCssClasses[signpostDirection]"
+        aria-live="polite"
+    >
+        <div class="border bg-white p-3" [ngClass]="overlayMaxWidthClassSignal()">
+            <ng-content></ng-content>
+        </div>
+
+        <puibe-tooltip-icon [style]="postTranslationCssStyle"></puibe-tooltip-icon>
+    </div>
+</ng-template>

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.ts
@@ -1,0 +1,229 @@
+import { CdkOverlayOrigin, ConnectedPosition, Overlay, OverlayModule, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { CommonModule, DOCUMENT } from '@angular/common';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    HostListener,
+    OnDestroy,
+    TemplateRef,
+    ViewContainerRef,
+    inject,
+    input,
+    viewChild,
+} from '@angular/core';
+import { DestroyService } from '@nexplore/practices-ui';
+import { TranslateModule } from '@ngx-translate/core';
+import { takeUntil } from 'rxjs';
+import { PuibeTooltipIconComponent } from './tooltip-icon.component';
+
+type TooltipDirection = 'top' | 'bottom' | 'left' | 'right' | 'auto';
+
+const OVERLAY_POSITIONS: { [K in TooltipDirection]: ConnectedPosition } = {
+    top: {
+        originX: 'center',
+        originY: 'top',
+        overlayX: 'center',
+        overlayY: 'bottom',
+    },
+    bottom: {
+        originX: 'center',
+        originY: 'bottom',
+        overlayX: 'center',
+        overlayY: 'top',
+    },
+    left: {
+        originX: 'start',
+        originY: 'center',
+        overlayX: 'end',
+        overlayY: 'center',
+    },
+    right: {
+        originX: 'end',
+        originY: 'center',
+        overlayX: 'start',
+        overlayY: 'center',
+    },
+    auto: {
+        originX: 'center',
+        originY: 'center',
+        overlayX: 'center',
+        overlayY: 'center',
+    },
+};
+
+const SIGNPOST_SIGN_CSS_CLASSES: { [K in TooltipDirection]: string } = {
+    top: 'flex-col',
+    bottom: 'flex-col-reverse',
+    left: 'flex-row',
+    right: 'flex-row-reverse',
+    auto: 'flex-col',
+};
+
+const SIGNPOST_POST_CSS_STYLES: { [K in TooltipDirection]: string } = {
+    top: ` translateY(-13px)`,
+    bottom: ` translateY(13px) rotate(180deg)`,
+    left: ` translateX(-8px) rotate(270deg)`,
+    right: ` translateX(8px) rotate(90deg)`,
+    auto: 'display: none',
+};
+
+let nextUniqueId = 0;
+
+@Component({
+    selector: 'puibe-tooltip-button',
+    imports: [CommonModule, OverlayModule, TranslateModule, PuibeTooltipIconComponent],
+    providers: [DestroyService],
+    templateUrl: './tooltip.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        class: 'inline',
+    },
+})
+export class PuibeTooltipButtonComponent implements AfterViewInit, OnDestroy {
+    private readonly _document = inject<Document>(DOCUMENT);
+    private readonly _overlayService = inject(Overlay);
+    private readonly _destroy$ = inject(DestroyService);
+    private readonly _viewContainerRef = inject(ViewContainerRef);
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    public readonly overlayMaxWidthClassSignal = input<string>('max-w-md', { alias: 'overlayMaxWidthClass' });
+
+    private readonly _originSignal = viewChild(CdkOverlayOrigin);
+    private readonly _signpostRefSignal = viewChild(TemplateRef<HTMLDivElement>);
+
+    protected readonly signCssClasses: { [K in TooltipDirection]: string } = SIGNPOST_SIGN_CSS_CLASSES;
+    protected readonly tooltipId = `tooltip-${nextUniqueId++}`;
+    protected signpostDirection: TooltipDirection = 'top';
+    protected postTranslationCssStyle = '';
+
+    private _overlayRef: OverlayRef | undefined;
+    private _templatePortal: TemplatePortal<HTMLDivElement> | undefined;
+    private _overlayObserver: MutationObserver | undefined;
+
+    @HostListener('document:keydown.escape') onKeydownHandler() {
+        this._overlayRef?.detach();
+    }
+
+    public toggle() {
+        if (this._overlayRef?.hasAttached()) {
+            this._overlayRef?.detach();
+            return;
+        }
+        this._overlayRef?.attach(this._templatePortal);
+    }
+
+    public ngAfterViewInit(): void {
+        const signpostRef = this._signpostRefSignal();
+        if (!signpostRef) {
+            return;
+        }
+
+        this._templatePortal = new TemplatePortal(signpostRef, this._viewContainerRef);
+
+        const scrollStrategy = this._overlayService.scrollStrategies.close();
+
+        const overlayConfig = {
+            hasBackdrop: true,
+            backdropClass: 'cdk-overlay-transparent-backdrop',
+            scrollStrategy,
+        };
+
+        this._overlayRef = this._overlayService.create(overlayConfig);
+
+        this._overlayRef
+            .backdropClick()
+            .pipe(takeUntil(this._destroy$))
+            .subscribe(() => this._overlayRef?.detach());
+
+        this._overlayObserver = new MutationObserver(() => this.setOverlayDirection());
+        this._overlayObserver.observe(this._overlayRef.overlayElement, {
+            attributes: false,
+            childList: true,
+            subtree: false,
+        });
+    }
+
+    public ngOnDestroy(): void {
+        this._overlayRef?.dispose();
+        this._overlayObserver?.disconnect();
+    }
+
+    private setOverlayDirection() {
+        const origin = this._originSignal();
+        if (!origin || !this._overlayRef) {
+            return;
+        }
+        if (!this._overlayRef.hasAttached()) {
+            return;
+        }
+
+        this.findOverlayDirection(origin, this._overlayRef);
+
+        const positionStrategy = this._overlayService
+            .position()
+            .flexibleConnectedTo(origin.elementRef)
+            .withFlexibleDimensions(true)
+            .withPush(true)
+            .withGrowAfterOpen(true)
+            .withPositions([OVERLAY_POSITIONS[this.signpostDirection]]);
+
+        this._overlayRef.updatePositionStrategy(positionStrategy);
+        this._overlayRef.updatePosition();
+
+        this.setPostOffset(origin, this._overlayRef);
+
+        this._cdr.detectChanges();
+    }
+
+    private findOverlayDirection(origin: CdkOverlayOrigin, overlayRef: OverlayRef) {
+        const defaultWindow = this._document.defaultView;
+        if (defaultWindow) {
+            // Determine the direction of the signpost, based on the space around the origin and the size of the overlay
+            const { top, left, width, height } = origin.elementRef.nativeElement.getBoundingClientRect();
+            const { width: overlayWidth, height: overlayHeight } = overlayRef.overlayElement.getBoundingClientRect();
+            const spaceTop = top;
+            const spaceLeft = left;
+            const spaceRight = defaultWindow.innerWidth - (spaceLeft + width);
+            const spaceBottom = defaultWindow.innerHeight - (spaceTop + height);
+
+            const solutions: { [K in TooltipDirection]: boolean } = {
+                top: spaceTop >= overlayHeight,
+                bottom: spaceBottom >= overlayHeight,
+                left: spaceLeft >= overlayWidth,
+                right: spaceRight >= overlayWidth,
+                auto: true,
+            };
+
+            this.signpostDirection = Object.entries(solutions).filter(
+                (entry) => entry[1] === true
+            )[0][0] as TooltipDirection;
+        }
+    }
+
+    private setPostOffset(origin: CdkOverlayOrigin, overlayRef: OverlayRef) {
+        const { top, left, width, height } = origin.elementRef.nativeElement.getBoundingClientRect();
+        const {
+            width: overlayWidth,
+            height: overlayHeight,
+            top: overlayTop,
+            left: overlayLeft,
+        } = overlayRef.overlayElement.getBoundingClientRect();
+
+        const horizontalCenter = left + width / 2;
+        const verticalCenter = top + height / 2;
+        const overlayHorizontalCenter = overlayLeft + overlayWidth / 2;
+        const overlayVerticalCenter = overlayTop + overlayHeight / 2;
+
+        this.postTranslationCssStyle =
+            {
+                top: `transform: translateX(${horizontalCenter - overlayHorizontalCenter}px)`,
+                bottom: `transform: translateX(${horizontalCenter - overlayHorizontalCenter}px)`,
+                left: `transform: translateY(${verticalCenter - overlayVerticalCenter}px)`,
+                right: `transform: translateY(${verticalCenter - overlayVerticalCenter}px)`,
+                auto: '',
+            }[this.signpostDirection] + SIGNPOST_POST_CSS_STYLES[this.signpostDirection];
+    }
+}

--- a/ng/practices-ui-tailwind/src/index.ts
+++ b/ng/practices-ui-tailwind/src/index.ts
@@ -103,6 +103,8 @@ export * from './lib/date-input/date-input.directive';
 export * from './lib/date-input/month-input.directive';
 export * from './lib/date-input/year-input.directive';
 
+export * from './lib/tooltip/tooltip.component';
+
 export * from './lib/radio-button/radio-button-group.component';
 export * from './lib/radio-button/radio-button.component';
 
@@ -198,4 +200,3 @@ export * from './lib/command/command-from-legacy-command-util';
 export * from './select.module';
 export * from './shell.module';
 export * from './table.module';
-

--- a/ng/practices-ui-tailwind/src/lib/radio-button/radio-button.component.html
+++ b/ng/practices-ui-tailwind/src/lib/radio-button/radio-button.component.html
@@ -34,10 +34,16 @@
       ></div>
     </div>
   </div>
-  <div class="flex flex-col">
+  <div>
     {{ label }}
     @if (description) {
-      <span class="text-very-small">{{ description }}</span>
+      @if (descriptionAsTooltip) {
+        <pui-tooltip-button class="ml-1" ariaLabel="More information">
+          <p class="text-small">{{ description }}</p>
+        </pui-tooltip-button>
+      } @else {
+        <span class="block text-very-small">{{ description }}</span>
+      }
     }
   </div>
 </label>

--- a/ng/practices-ui-tailwind/src/lib/radio-button/radio-button.component.ts
+++ b/ng/practices-ui-tailwind/src/lib/radio-button/radio-button.component.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { PuiFormFieldService } from '@nexplore/practices-ng-forms';
 import { map } from 'rxjs';
 import { RadioButtonGroupService } from './radio-button-group.service';
+import { PuiTooltipButtonComponent } from '../tooltip/tooltip.component';
 
 let nextUniqueId = 0;
 
@@ -12,7 +13,7 @@ let nextUniqueId = 0;
     selector: 'pui-radio-button',
     templateUrl: './radio-button.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgClass, ReactiveFormsModule, AsyncPipe],
+    imports: [NgClass, ReactiveFormsModule, AsyncPipe, PuiTooltipButtonComponent],
 })
 export class PuiRadioButtonComponent {
     private _radioButtonGroupService = inject(RadioButtonGroupService);
@@ -26,6 +27,9 @@ export class PuiRadioButtonComponent {
 
     @Input()
     description: string;
+
+    @Input()
+    descriptionAsTooltip = false;
 
     uniqueId = `radio-button-${nextUniqueId++}`;
 
@@ -48,4 +52,3 @@ export class PuiRadioButtonComponent {
         this._radioButtonGroupService.setValue(this.value);
     }
 }
-

--- a/ng/practices-ui-tailwind/src/lib/tooltip/tooltip.component.html
+++ b/ng/practices-ui-tailwind/src/lib/tooltip/tooltip.component.html
@@ -1,0 +1,23 @@
+<button
+  cdkOverlayOrigin
+  type="button"
+  class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-borderbutton-default bg-bgbutton-default text-small font-bold leading-none text-fgbutton-default transition-all duration-200 ease-in-out hover:scale-110 focus:scale-110 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-[-webkit-focus-ring-color]"
+  (click)="toggle()"
+  [attr.aria-describedby]="tooltipId"
+  [attr.aria-label]="ariaLabel()"
+  [attr.aria-expanded]="isOpen"
+>
+  ?
+</button>
+
+<ng-template>
+  <div
+    role="tooltip"
+    [id]="tooltipId"
+    class="z-50 border border-gray bg-white p-3 text-small font-normal text-foreground shadow-sidepane"
+    [ngClass]="[overlayMaxWidthClass(), arrowClass]"
+    aria-live="polite"
+  >
+    <ng-content></ng-content>
+  </div>
+</ng-template>

--- a/ng/practices-ui-tailwind/src/lib/tooltip/tooltip.component.ts
+++ b/ng/practices-ui-tailwind/src/lib/tooltip/tooltip.component.ts
@@ -1,0 +1,208 @@
+import { CdkOverlayOrigin, ConnectedPosition, Overlay, OverlayModule, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { CommonModule, DOCUMENT } from '@angular/common';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    HostListener,
+    OnDestroy,
+    TemplateRef,
+    ViewContainerRef,
+    inject,
+    input,
+    viewChild,
+} from '@angular/core';
+import { DestroyService } from '@nexplore/practices-ui';
+import { takeUntil } from 'rxjs';
+
+type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
+
+const OVERLAY_POSITIONS: { [K in TooltipDirection]: ConnectedPosition } = {
+    top: {
+        originX: 'center',
+        originY: 'top',
+        overlayX: 'center',
+        overlayY: 'bottom',
+        offsetY: -12,
+    },
+    bottom: {
+        originX: 'center',
+        originY: 'bottom',
+        overlayX: 'center',
+        overlayY: 'top',
+        offsetY: 12,
+    },
+    left: {
+        originX: 'start',
+        originY: 'center',
+        overlayX: 'end',
+        overlayY: 'center',
+        offsetX: -12,
+    },
+    right: {
+        originX: 'end',
+        originY: 'center',
+        overlayX: 'start',
+        overlayY: 'center',
+        offsetX: 12,
+    },
+};
+
+let nextUniqueId = 0;
+
+@Component({
+    standalone: true,
+    selector: 'pui-tooltip-button',
+    imports: [CommonModule, OverlayModule],
+    providers: [DestroyService],
+    templateUrl: './tooltip.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        class: 'inline-flex align-middle',
+    },
+})
+export class PuiTooltipButtonComponent implements AfterViewInit, OnDestroy {
+    private readonly _document = inject<Document>(DOCUMENT);
+    private readonly _overlayService = inject(Overlay);
+    private readonly _destroy$ = inject(DestroyService);
+    private readonly _viewContainerRef = inject(ViewContainerRef);
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    public readonly ariaLabel = input('More information');
+    public readonly overlayMaxWidthClass = input('max-w-md');
+
+    private readonly _originSignal = viewChild(CdkOverlayOrigin);
+    private readonly _tooltipRefSignal = viewChild(TemplateRef<HTMLDivElement>);
+
+    protected readonly tooltipId = `pui-tooltip-${nextUniqueId++}`;
+    protected arrowClass = 'arrowtip-bottom arrowtip-center';
+    protected isOpen = false;
+
+    private _overlayRef: OverlayRef | undefined;
+    private _templatePortal: TemplatePortal<HTMLDivElement> | undefined;
+
+    @HostListener('document:keydown.escape')
+    onEscape() {
+        this.close();
+    }
+
+    public toggle() {
+        if (this._overlayRef?.hasAttached()) {
+            this.close();
+            return;
+        }
+
+        if (!this._overlayRef || !this._templatePortal) {
+            return;
+        }
+
+        this._overlayRef.attach(this._templatePortal);
+        this.isOpen = true;
+        this.setOverlayDirection();
+        this._cdr.markForCheck();
+    }
+
+    public ngAfterViewInit(): void {
+        const tooltipRef = this._tooltipRefSignal();
+        const origin = this._originSignal();
+        if (!tooltipRef || !origin) {
+            return;
+        }
+
+        this._templatePortal = new TemplatePortal(tooltipRef, this._viewContainerRef);
+        this._overlayRef = this._overlayService.create({
+            hasBackdrop: true,
+            backdropClass: 'cdk-overlay-transparent-backdrop',
+            positionStrategy: this.createPositionStrategy(origin, 'top'),
+            scrollStrategy: this._overlayService.scrollStrategies.close(),
+        });
+
+        this._overlayRef
+            .backdropClick()
+            .pipe(takeUntil(this._destroy$))
+            .subscribe(() => this.close());
+
+        this._overlayRef
+            .detachments()
+            .pipe(takeUntil(this._destroy$))
+            .subscribe(() => {
+                this.isOpen = false;
+                this._cdr.markForCheck();
+            });
+    }
+
+    public ngOnDestroy(): void {
+        this._overlayRef?.dispose();
+    }
+
+    private close() {
+        this._overlayRef?.detach();
+        this.isOpen = false;
+        this._cdr.markForCheck();
+    }
+
+    private setOverlayDirection() {
+        const origin = this._originSignal();
+        if (!origin || !this._overlayRef?.hasAttached()) {
+            return;
+        }
+
+        const direction = this.findOverlayDirection(origin, this._overlayRef);
+        this.arrowClass = this.getArrowClass(direction);
+        this._overlayRef.updatePositionStrategy(this.createPositionStrategy(origin, direction));
+        this._overlayRef.updatePosition();
+    }
+
+    private createPositionStrategy(origin: CdkOverlayOrigin, direction: TooltipDirection) {
+        return this._overlayService
+            .position()
+            .flexibleConnectedTo(origin.elementRef)
+            .withFlexibleDimensions(true)
+            .withPush(true)
+            .withGrowAfterOpen(true)
+            .withPositions([OVERLAY_POSITIONS[direction]]);
+    }
+
+    private findOverlayDirection(origin: CdkOverlayOrigin, overlayRef: OverlayRef): TooltipDirection {
+        const defaultWindow = this._document.defaultView;
+        if (!defaultWindow) {
+            return 'top';
+        }
+
+        const { top, left, width, height } = origin.elementRef.nativeElement.getBoundingClientRect();
+        const { width: overlayWidth, height: overlayHeight } = overlayRef.overlayElement.getBoundingClientRect();
+        const spaceTop = top;
+        const spaceLeft = left;
+        const spaceRight = defaultWindow.innerWidth - (spaceLeft + width);
+        const spaceBottom = defaultWindow.innerHeight - (spaceTop + height);
+
+        if (spaceTop >= overlayHeight) {
+            return 'top';
+        }
+
+        if (spaceBottom >= overlayHeight) {
+            return 'bottom';
+        }
+
+        if (spaceRight >= overlayWidth) {
+            return 'right';
+        }
+
+        if (spaceLeft >= overlayWidth) {
+            return 'left';
+        }
+
+        return 'top';
+    }
+
+    private getArrowClass(direction: TooltipDirection): string {
+        return {
+            top: 'arrowtip-bottom arrowtip-center',
+            bottom: 'arrowtip-top arrowtip-center',
+            left: 'arrowtip-right arrowtip-center',
+            right: 'arrowtip-left arrowtip-center',
+        }[direction];
+    }
+}


### PR DESCRIPTION
## Description

This branch synchronizes the Tailwind tooltip maintenance line with current `main` and ports the reusable radio-button-description-as-tooltip capability across the UI packages. It adds a generic Tailwind `pui-tooltip` component, wires the Tailwind radio-button components to render their descriptions as a tooltip when `descriptionAsTooltip` is requested, and exports the tooltip from the Tailwind package surface. It also carries the matching KTBE tooltip/radio changes so the generic Tailwind port stays aligned with the upstream UI behavior.

The branch now includes current `main` through `e56c3bf`, including the 11.3.0 / .NET 10 dependency release, `TimeProviderClock`, the KTBE expansion-panel left-content/truncated-heading work, and the PR labeler/release-drafter workflow updates. The merge normalized the prior PR-local whitespace/EOF noise so the Tailwind maintenance diff stays `git diff --check` clean.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verification relies on GitHub Actions CI plus local Git object checks rather than a manual Storybook or full local build. The current head is `623a7dc`; Build & Test run 244 passed: https://github.com/nexplore/nexplore-practices/actions/runs/28641091739. The run's `BuildPackAll`, artifact upload, and post-job steps all completed successfully. Prior Build & Test runs passed on `63d821d` ([run 230](https://github.com/nexplore/nexplore-practices/actions/runs/28459018492)), `a3d8327` ([run 225](https://github.com/nexplore/nexplore-practices/actions/runs/28426797914)), and `fe15fba` ([run 218](https://github.com/nexplore/nexplore-practices/actions/runs/28354951590)).

Local verification before publication used a fresh full clone. Merging current `main` into the PR branch completed without conflicts; the connector-created tree `126d0ea1b78e3af01c947027af2eed21c60aaf75` matched the verified local tree. `git diff --check origin/feature/tailwind-4-new-library...HEAD` passed, and `git merge-tree --write-tree origin/feature/tailwind-4-new-library HEAD` returned the same tree `126d0ea1b78e3af01c947027af2eed21c60aaf75`.

## Integration Instructions

Consumers of `IClock` should note that `Today` and `UtcToday` now return `DateOnly` from the merged `TimeProviderClock` change and update call sites accordingly. No other integration steps are required for the Tailwind/KTBE tooltip additions, which are additive.