### PR TITLE
[codex] Fix data-protection key persistence on PR #36

### DIFF
--- a/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
@@ -40,7 +40,7 @@ namespace Nexplore.Practices.EntityFramework.Security
                 };
 
                 dataContext.Set<DataProtectionKey>().Add(newKey);
-                dataContext.SaveChanges();
+                dataContext.SaveChangesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             }
         }
 

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
@@ -8,22 +8,31 @@ namespace Nexplore.Practices.EntityFramework.Security
     using Microsoft.AspNetCore.DataProtection.Repositories;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
     using Nexplore.Practices.EntityFramework.Configuration;
 
     public class DataProtectionKeyRepository : IXmlRepository
     {
         private readonly ILogger<DataMisalignedException> logger;
-        private readonly IDbContextFactory dbContextFactory;
+        private readonly IDbContextOptionsProvider contextOptionsProvider;
+        private readonly IDbModelCreator modelCreator;
+        private readonly IOptions<DatabaseOptions> databaseOptions;
 
-        public DataProtectionKeyRepository(ILogger<DataMisalignedException> logger, IDbContextFactory dbContextFactory)
+        public DataProtectionKeyRepository(
+            ILogger<DataMisalignedException> logger,
+            IDbContextOptionsProvider contextOptionsProvider,
+            IDbModelCreator modelCreator,
+            IOptions<DatabaseOptions> databaseOptions)
         {
             this.logger = logger;
-            this.dbContextFactory = dbContextFactory;
+            this.contextOptionsProvider = contextOptionsProvider;
+            this.modelCreator = modelCreator;
+            this.databaseOptions = databaseOptions;
         }
 
         public virtual IReadOnlyCollection<XElement> GetAllElements()
         {
-            using (var dataContext = this.dbContextFactory.Create())
+            using (var dataContext = this.CreateDataProtectionContext())
             {
                 return dataContext.Set<DataProtectionKey>().AsNoTracking().Select(key => TryParseKeyXml(key.Xml, this.logger)).ToList().AsReadOnly();
             }
@@ -31,7 +40,7 @@ namespace Nexplore.Practices.EntityFramework.Security
 
         public virtual void StoreElement(XElement element, string friendlyName)
         {
-            using (var dataContext = this.dbContextFactory.Create())
+            using (var dataContext = this.CreateDataProtectionContext())
             {
                 var newKey = new DataProtectionKey
                 {
@@ -40,8 +49,15 @@ namespace Nexplore.Practices.EntityFramework.Security
                 };
 
                 dataContext.Set<DataProtectionKey>().Add(newKey);
-                dataContext.SaveChangesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                dataContext.SaveChanges();
             }
+        }
+
+        protected virtual DbContext CreateDataProtectionContext()
+        {
+            var context = new DataProtectionDbContext(this.contextOptionsProvider, this.modelCreator);
+            context.ChangeTracker.AutoDetectChangesEnabled = this.databaseOptions.Value.AutoDetectChangesEnabled;
+            return context;
         }
 
         private static XElement TryParseKeyXml(string xml, ILogger logger)
@@ -54,6 +70,35 @@ namespace Nexplore.Practices.EntityFramework.Security
             {
                 logger?.LogError(exception, "Could not parse xml");
                 return null;
+            }
+        }
+
+        private sealed class DataProtectionDbContext : DbContext, IDataProtectionKeyContext
+        {
+            private readonly IDbContextOptionsProvider contextOptionsProvider;
+            private readonly IDbModelCreator modelCreator;
+
+            public DataProtectionDbContext(IDbContextOptionsProvider contextOptionsProvider, IDbModelCreator modelCreator)
+            {
+                this.contextOptionsProvider = contextOptionsProvider;
+                this.modelCreator = modelCreator;
+            }
+
+            public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                this.contextOptionsProvider.OnConfiguring(optionsBuilder);
+            }
+
+            protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+            {
+                this.modelCreator.ConfigureConventions(configurationBuilder);
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                this.modelCreator.OnModelCreating(modelBuilder);
             }
         }
     }

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
@@ -1,0 +1,72 @@
+namespace Nexplore.Practices.Tests.Unit.EntityFramework.Security
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Storage;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Nexplore.Practices.EntityFramework.Configuration;
+    using Nexplore.Practices.EntityFramework.Security;
+    using NSubstitute;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DataProtectionKeyRepositoryTests
+    {
+        [Test]
+        public void StoreElement_WithAsyncOnlyDbContext_PersistsKey()
+        {
+            // Arrange
+            var databaseName = Guid.NewGuid().ToString();
+            var dbContextFactory = Substitute.For<IDbContextFactory>();
+            dbContextFactory.Create(Arg.Any<IDbContextTransaction>()).Returns(_ => CreateDataProtectionContext(databaseName));
+
+            var repository = new DataProtectionKeyRepository(NullLogger<DataMisalignedException>.Instance, dbContextFactory);
+            var element = XElement.Parse("<key id=\"test-key\" />");
+
+            // Act
+            repository.StoreElement(element, "test-friendly-name");
+
+            // Assert
+            using (var dataContext = CreateDataProtectionContext(databaseName))
+            {
+                var key = dataContext.Set<DataProtectionKey>().SingleAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+
+                Assert.That(key.FriendlyName, Is.EqualTo("test-friendly-name"));
+                Assert.That(key.Xml, Is.EqualTo(element.ToString(SaveOptions.DisableFormatting)));
+            }
+        }
+
+        private static TestDataProtectionContext CreateDataProtectionContext(string databaseName)
+        {
+            var options = new DbContextOptionsBuilder<TestDataProtectionContext>()
+                .UseInMemoryDatabase(databaseName)
+                .Options;
+
+            return new TestDataProtectionContext(options);
+        }
+
+        private sealed class TestDataProtectionContext : DbContext, IDataProtectionKeyContext
+        {
+            public TestDataProtectionContext(DbContextOptions<TestDataProtectionContext> options)
+                : base(options)
+            {
+            }
+
+            public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+
+            public override int SaveChanges(bool acceptAllChangesOnSuccess)
+            {
+                throw new NotSupportedException("Synchronous save is not supported anymore, use SaveChangesAsync.");
+            }
+
+            public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+            {
+                return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+            }
+        }
+    }
+}

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
@@ -1,30 +1,30 @@
 namespace Nexplore.Practices.Tests.Unit.EntityFramework.Security
 {
     using System;
-    using System.Threading;
-    using System.Threading.Tasks;
     using System.Xml.Linq;
     using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore;
-    using Microsoft.EntityFrameworkCore.Storage;
     using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Extensions.Options;
     using Nexplore.Practices.EntityFramework.Configuration;
     using Nexplore.Practices.EntityFramework.Security;
-    using NSubstitute;
     using NUnit.Framework;
 
     [TestFixture]
     public class DataProtectionKeyRepositoryTests
     {
         [Test]
-        public void StoreElement_WithAsyncOnlyDbContext_PersistsKey()
+        public void StoreElement_WithPlainDataProtectionContext_PersistsKeySynchronously()
         {
             // Arrange
             var databaseName = Guid.NewGuid().ToString();
-            var dbContextFactory = Substitute.For<IDbContextFactory>();
-            dbContextFactory.Create(Arg.Any<IDbContextTransaction>()).Returns(_ => CreateDataProtectionContext(databaseName));
-
-            var repository = new DataProtectionKeyRepository(NullLogger<DataMisalignedException>.Instance, dbContextFactory);
+            var contextOptionsProvider = new InMemoryContextOptionsProvider(databaseName);
+            var modelCreator = new DataProtectionTestModelCreator();
+            var repository = new DataProtectionKeyRepository(
+                NullLogger<DataMisalignedException>.Instance,
+                contextOptionsProvider,
+                modelCreator,
+                Options.Create(new DatabaseOptions()));
             var element = XElement.Parse("<key id=\"test-key\" />");
 
             // Act
@@ -49,6 +49,33 @@ namespace Nexplore.Practices.Tests.Unit.EntityFramework.Security
             return new TestDataProtectionContext(options);
         }
 
+        private sealed class InMemoryContextOptionsProvider : IDbContextOptionsProvider
+        {
+            private readonly string databaseName;
+
+            public InMemoryContextOptionsProvider(string databaseName)
+            {
+                this.databaseName = databaseName;
+            }
+
+            public void OnConfiguring(DbContextOptionsBuilder builder)
+            {
+                builder.UseInMemoryDatabase(this.databaseName);
+            }
+        }
+
+        private sealed class DataProtectionTestModelCreator : IDbModelCreator
+        {
+            public void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+            {
+            }
+
+            public void OnModelCreating(ModelBuilder builder)
+            {
+                builder.Entity<DataProtectionKey>();
+            }
+        }
+
         private sealed class TestDataProtectionContext : DbContext, IDataProtectionKeyContext
         {
             public TestDataProtectionContext(DbContextOptions<TestDataProtectionContext> options)
@@ -57,16 +84,6 @@ namespace Nexplore.Practices.Tests.Unit.EntityFramework.Security
             }
 
             public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
-
-            public override int SaveChanges(bool acceptAllChangesOnSuccess)
-            {
-                throw new NotSupportedException("Synchronous save is not supported anymore, use SaveChangesAsync.");
-            }
-
-            public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
-            {
-                return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
-            }
         }
     }
 }

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
@@ -6,14 +6,17 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.15" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.15" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Kontext

Stacked Fix für #36 (`feature/introduce-async-validation`) auf exakt Head `f3c42710fa436f497a671fba06b3fbec22e43251`.

Codex Cloud Tasks:

- Initialer Fix: https://chatgpt.com/codex/tasks/task_e_6a40f6ebae8c8325b642f735809257a2
- Refactor nach Review-Feedback: https://chatgpt.com/codex/tasks/task_e_6a42984c53ec8325a658bc7688f86def

## Problem

PR #36 macht `EntityFrameworkContext.SaveChanges(bool)` absichtlich unbrauchbar. `DataProtectionKeyRepository.StoreElement` ruft aber weiterhin `SaveChanges()` auf; wenn der Data-Protection-Pfad über den Practices-DbContext läuft, würde das Speichern neuer Data-Protection-Keys mit `NotSupportedException` abbrechen.

## Änderung

- `DataProtectionKeyRepository` erzeugt für den Data-Protection-Pfad einen eigenen internen `DataProtectionDbContext`.
- Der Context nutzt weiterhin `IDbContextOptionsProvider` und `IDbModelCreator`, läuft aber nicht über `EntityFrameworkContext` und damit nicht über dessen Validation-/Audit-/Metadata-Pipeline.
- `StoreElement` nutzt wieder synchrones `SaveChanges()` auf diesem plain Data-Protection-Context.
- Der Unit Test prüft, dass ein Key über den plain Context synchron persistiert wird.
- EF InMemory bleibt für die Unit Tests je Target Framework ergänzt.

## Verifikation

Lokal mit .NET SDK `10.0.101` und Runtimes `8.0.26`, `9.0.15`, `10.0.1`:

- `git diff --cached --check` passed
- `dotnet test dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj --filter FullyQualifiedName~DataProtectionKeyRepositoryTests --verbosity normal` passed on `net8.0`, `net9.0`, `net10.0` (1/1 each)
- `dotnet test dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj --no-restore --verbosity minimal` passed on `net8.0`, `net9.0`, `net10.0` (213 passed, 1 skipped each)

Draft bleibt draft für Maintainer-Review.