### PR TITLE
Add PR template and description-based labeler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,17 @@
-Fixes #
+## Description
 
-## Proposed Changes
+<_Include a description of the change and why this change was made._>
 
--
--
--
+- [ ] Impacts functionality?
+- [ ] Impacts security?
+- [ ] Breaking change?
+- [ ] Includes tests?
+- [ ] Includes documentation?
+
+## How This Was Tested
+
+<_Describe the test(s) that were run to verify the changes._>
+
+## Integration Instructions
+
+<_Describe how these changes should be integrated. Use N/A if nothing is required._>

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,49 @@
+# Canonical label definitions, synced to the repo by .github/workflows/label-sync.yaml.
+# Format: https://github.com/crazy-max/ghaction-github-labeler
+
+- name: impact:breaking-change
+  description: Requires integration attention
+  color: 'a54418'
+  aliases: []
+- name: impact:non-functional
+  description: Does not have a functional impact
+  color: 'c2e0c6'
+  aliases: []
+- name: impact:security
+  description: Has a security impact
+  color: '31df8c'
+  aliases: []
+- name: impact:testing
+  description: Affects testing
+  color: 'd4c5f9'
+  aliases: []
+
+- name: type:bug
+  description: Something isn't working
+  color: 'd73a4a'
+  aliases: []
+- name: type:documentation
+  description: Improvements or additions to documentation
+  color: '0075ca'
+  aliases: []
+- name: type:enhancement
+  description: New feature or pull request
+  color: 'a2eeef'
+  aliases: []
+- name: type:feature-request
+  description: A new feature proposal
+  color: 'a9dfbf'
+  aliases: []
+
+- name: semver:major
+  description: Pull requests that should increment the release major version
+  color: '000000'
+  aliases: []
+- name: semver:minor
+  description: Pull requests that should increment the release minor version
+  color: '000000'
+  aliases: []
+- name: semver:patch
+  description: Pull requests that should increment the release patch version
+  color: '000000'
+  aliases: []

--- a/.github/release-draft-config.yml
+++ b/.github/release-draft-config.yml
@@ -1,0 +1,91 @@
+# Minimal release-drafter config, inspired by OpenDevicePartnership/patina.
+# Categorizes merged PRs by the impact:* / type:* labels applied by the labeler.
+# Used by .github/workflows/release-drafter.yaml.
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+commitish: refs/heads/main
+filter-by-commitish: true
+
+template: |
+  # What's Changed
+
+  $CHANGES
+
+  Packages are hosted here: https://github.com/orgs/nexplore/packages?repo_name=nexplore-practices
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: '⚠️ Breaking Changes'
+    when:
+      labels:
+        - 'impact:breaking-change'
+  - title: '🚀 Features & ✨ Enhancements'
+    when:
+      labels:
+        - 'type:enhancement'
+        - 'type:feature-request'
+  - title: '🐛 Bug Fixes'
+    when:
+      labels:
+        - 'type:bug'
+  - title: '🔐 Security Impacting'
+    when:
+      labels:
+        - 'impact:security'
+  - title: '📖 Documentation'
+    when:
+      labels:
+        - 'type:documentation'
+  - title: '🧪 Tests'
+    when:
+      labels:
+        - 'impact:testing'
+
+  # type: version-resolver categories only affect the bump, not the changelog.
+  - type: version-resolver
+    semver-increment: major
+    when:
+      labels:
+        - 'semver:major'
+        - 'impact:breaking-change'
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      labels:
+        - 'semver:minor'
+        - 'type:enhancement'
+        - 'type:feature-request'
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      labels:
+        - 'semver:patch'
+        - 'impact:non-functional'
+        - 'type:bug'
+        - 'type:documentation'
+  # No `when` → default increment when nothing else matches (was `default: patch`).
+  - type: version-resolver
+    semver-increment: patch
+
+change-template: >-
+  <ul>
+    <li>
+      $TITLE @$AUTHOR (#$NUMBER)
+      <br>
+      <details>
+        <summary>Change Details</summary>
+        <blockquote>
+          <!-- Non-breaking space to have content if body is empty -->
+          &nbsp; $BODY
+        </blockquote>
+        <hr>
+      </details>
+    </li>
+  </ul>
+
+change-title-escapes: '\<*_&@' # Note: @ is added to disable mentions
+
+exclude-contributors:
+  - 'github-actions[bot]'
+  - 'dependabot[bot]'

--- a/.github/workflows/build.template.yml
+++ b/.github/workflows/build.template.yml
@@ -6,22 +6,22 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: dotnet/global.json
           dotnet-version: "8.x"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22.14.0"
           check-latest: true
       - run: chmod +x ./build.sh
       - run: ./build.sh BuildPackAll
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-output
           path: .nuke/temp/output

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -1,0 +1,28 @@
+name: "label-sync"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/label-sync.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    name: Sync labels
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: true
+          dry-run: false

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,32 @@
+name: "labeler"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PRs
+    runs-on: ubuntu-slim
+    steps:
+      - name: Apply Labels Based on PR File Paths
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          configuration-path: .github/workflows/labeler/branches.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: false # Whether or not to remove labels when matching files are reverted or no longer changed by the PR
+
+      - name: Label pull request from description
+        uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/workflows/labeler/regex-pull-requests.yml
+          enable-versioned-regex: 0
+          include-title: 0
+          include-body: 1
+          sync-labels: 1

--- a/.github/workflows/labeler/branches.yml
+++ b/.github/workflows/labeler/branches.yml
@@ -1,0 +1,23 @@
+# Configuration for labeler - https://github.com/actions/labeler
+"type:enhancement":
+  - head-branch:
+    - '^feat/'
+    - '^feat-'
+    - '^feature/'
+    - '^feature-'
+
+"type:bug":
+  - head-branch:
+    - '^fix/'
+    - '^fix-'
+    - '^bugfix/'
+    - '^bugfix-'
+    - '^bug/'
+    - '^bug-'
+
+"type:documentation":
+  - head-branch:
+    - '^docs/'
+    - '^docs-'
+    - '^doc/'
+    - '^doc-'

--- a/.github/workflows/labeler/regex-pull-requests.yml
+++ b/.github/workflows/labeler/regex-pull-requests.yml
@@ -1,0 +1,22 @@
+# Labels applied to pull requests based on the checkboxes in the PR description.
+# Used by .github/workflows/labeler.yaml via github/issue-labeler.
+# See: https://github.com/github/issue-labeler
+#
+# These labels drive the Release notes categories in .github/release.yml.
+#
+# Keep labels in ascending alphabetical order.
+
+impact:breaking-change:
+  - '\s*-\s*\[\s*[xX]\s*\] Breaking change\?'
+
+impact:non-functional:
+  - '\s*-\s*\[\s*(?![xX])\s*\] Impacts functionality\?'
+
+impact:security:
+  - '\s*-\s*\[\s*[xX]\s*\] Impacts security\?'
+
+impact:testing:
+  - '\s*-\s*\[\s*[xX]\s*\] Includes tests\?'
+
+type:documentation:
+  - '\s*-\s*\[\s*[xX]\s*\] Includes documentation\?'

--- a/.github/workflows/publish.template.yml
+++ b/.github/workflows/publish.template.yml
@@ -25,32 +25,32 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
 
       # Prepare .NET like ADO UseDotNet (global.json + explicit 8.x)
       - name: Setup .NET from global.json
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: dotnet/global.json
 
       - name: Setup .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: "8.x"
 
       # Prepare Node.js like ADO UseNode@1
       - name: Setup Node 22.14.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22.14.0"
           check-latest: true
 
       # Download the build artifact named 'build-output' from the prior job
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-output
           path: ${{ runner.temp }}/build-output

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,25 @@
+name: "release-drafter"
+
+# Maintains a draft GitHub release, updating its notes on every push to main
+# based on merged pull requests and their impact:* / type:* labels.
+# Config: .github/release-draft-config.yml
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  draft:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Update release draft
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          config-name: release-draft-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NOTE: CHANGELOG.md is deprecated
+
+After the release of v11.3.0, please see the [GitHub release notes](https://github.com/nexplore/nexplore-practices/releases) for the practices in order to view the most up-to-date changes.
+
 # Changelog
 
 All notable changes to this library will be documented in this file.


### PR DESCRIPTION
## Description

Add a pull request template and automatic, description-driven labeling, inspired by [OpenDevicePartnership/patina](https://github.com/OpenDevicePartnership/patina). All third-party actions are pinned by SHA with a version comment and matching the existing `ci-build` workflow. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI/config-only change. All added YAML was validated with a parser locally. The labeler/label-sync workflows take effect once merged to `main`; this PR itself is a live first exercise of the new template and labeler.

## Integration Instructions

N/A — no consumer action required. After merge, `label-sync` creates the five labels and `labeler` runs automatically on subsequent pull requests.