### PR TITLE
Drop v prefix in release-drafter config to match tag scheme

### DIFF
--- a/.github/release-draft-config.yml
+++ b/.github/release-draft-config.yml
@@ -2,8 +2,8 @@
 # Categorizes merged PRs by the impact:* / type:* labels applied by the labeler.
 # Used by .github/workflows/release-drafter.yaml.
 
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 commitish: refs/heads/main
 filter-by-commitish: true
 
@@ -13,7 +13,7 @@ template: |
   $CHANGES
 
   Packages are hosted here: https://github.com/orgs/nexplore/packages?repo_name=nexplore-practices
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
 
 categories:
   - title: '⚠️ Breaking Changes'


### PR DESCRIPTION
## Description

The release-drafter config still used a `v` prefix in three places (`name-template`, `tag-template`, and the Full Changelog compare URL), while the repository's actual release tags carry no prefix (e.g. `13.0.0`). This made the generated compare link broken (`...v13.0.0`) and the tag/name templates inconsistent with reality. This change drops the `v` everywhere so the config matches the existing tagging scheme.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Change is limited to the release-drafter YAML config. Verified against existing tags (`13.0.0`, `12.1.0`, `11.3.0`), which confirm releases are tagged without a `v` prefix.

## Integration Instructions

N/A — takes effect automatically on the next release-drafter run.
