### PR TITLE
set tooltip button type to button to prevent form submit in practices-ui-ktbe

### DIFF
--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
@@ -1,4 +1,5 @@
 <button
+    type="button"
     cdkOverlayOrigin
     class="text-small leading-ktbe-small select-none rounded-full border bg-white px-[5px] py-0 font-bold transition-all duration-200 ease-in-out hover:scale-[1.2]"
     (click)="toggle()"


### PR DESCRIPTION
## Description

The tooltip trigger in `practices-ui-ktbe` renders a native `<button>` without an explicit `type`, so browsers default it to `type="submit"`. When the tooltip is used inside a form, clicking it to toggle the tooltip unintentionally submits the form. This change sets `type="button"` on the tooltip trigger so it only toggles the tooltip.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Manually verified that clicking the tooltip trigger inside a form toggles the tooltip without submitting the form.

## Integration Instructions

N/A — no API changes; consumers pick up the fix with the next package update.