### PR TITLE
Sync current main into Tailwind library branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
+- `Practices.Core` Added TimeProviderClock
+
+### Changed
+
+- `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Calling SaveChanges throws NotSupportedException
+- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
+- _BREAKING_ `Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
 - `practices-ui-ktbe` Added support for displaying custom left heading inside `PuibeExpansionPanelComponent` via a `heading-before` slot
 - `practices-ui-ktbe` Added `truncateHeading` input to `PuibeExpansionPanelComponent` to truncate long headings with ellipsis.
 
@@ -27,15 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Practices.Serilog` Updated Serilog.Settings.Configuration to 10.0.1
 - `Practices.Syncfusion.Excel` Updated Syncfusion.XlsIO.Net.Core to 33.2.15
 - `Practices.Syncfusion.Pdf` Updated Syncfusion.Pdf.Net.Core to 33.2.15
-
-### Added
-
-- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
-- `Practices.Core` Added TimeProviderClock
-- 
-### Changed
-
--  _BREAKING_`Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
 
 ## [11.2.2](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.2) - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `practices-ui-ktbe` Fixed KTBE Storybook styling by correcting Tailwind content paths in `samples-ktbe` and mapping Storybook static assets so font files under `/assets/fonts` are served correctly.
 - `Practices.Syncfusion.Excel` Fixed registration for ExcelEngine (memory leak)
 
 ## [11.2.1](https://github.com/nexplore/nexplore-practices/releases/tag/11.2.1) - 2026-04-17

--- a/dotnet/src/Nexplore.Practices.Core/Domain/Model/IAsyncValidatable.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Domain/Model/IAsyncValidatable.cs
@@ -1,0 +1,12 @@
+namespace Nexplore.Practices.Core.Domain.Model
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Nexplore.Practices.Core.Validation;
+
+    public interface IAsyncValidatable<in TValidationContext> : IValidatable
+    {
+        Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(TValidationContext context, CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/src/Nexplore.Practices.Core/Domain/Model/IValidatable.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Domain/Model/IValidatable.cs
@@ -5,9 +5,7 @@ namespace Nexplore.Practices.Core.Domain.Model
     using Nexplore.Practices.Core.Validation;
 
     [SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces", Justification = "Used as marker for all validatable entities, generic and non generic types necessary.")]
-    public interface IValidatable
-    {
-    }
+    public interface IValidatable;
 
     public interface IValidatable<in TValidationContext> : IValidatable
     {

--- a/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWork.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWork.cs
@@ -8,8 +8,6 @@ namespace Nexplore.Practices.Core.Scopes
     /// </summary>
     public interface IUnitOfWork : IChildScope
     {
-        void SaveChanges();
-
         Task SaveChangesAsync(CancellationToken cancellationToken = default);
     }
 

--- a/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWorkWithSingleDbTransaction.cs
+++ b/dotnet/src/Nexplore.Practices.Core/Scopes/IUnitOfWorkWithSingleDbTransaction.cs
@@ -8,8 +8,6 @@ namespace Nexplore.Practices.Core.Scopes
     /// </summary>
     public interface IUnitOfWorkWithSingleDbTransaction : IUnitOfWork
     {
-        void CommitDbTransaction();
-
         Task CommitDbTransactionAsync(CancellationToken cancellationToken = default);
     }
 

--- a/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/EntityFrameworkContext.cs
@@ -1,7 +1,6 @@
 namespace Nexplore.Practices.EntityFramework
 {
     using System;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
@@ -50,21 +49,12 @@ namespace Nexplore.Practices.EntityFramework
 
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
         {
-            this.PrepareSaveChanges();
-
-            try
-            {
-                return base.SaveChanges(acceptAllChangesOnSuccess);
-            }
-            catch (DbUpdateConcurrencyException)
-            {
-                throw new ConcurrencyException();
-            }
+            throw new NotSupportedException("Synchronous save is not supported anymore, use SaveChangesAsync.");
         }
 
         public override async Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
         {
-            this.PrepareSaveChanges();
+            await this.PrepareSaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
@@ -76,13 +66,13 @@ namespace Nexplore.Practices.EntityFramework
             }
         }
 
-        protected virtual void PrepareSaveChanges()
+        protected virtual async ValueTask PrepareSaveChangesAsync(CancellationToken cancellationToken)
         {
             this.ChangeTracker.DetectChanges();
 
             this.EnrichMetadata();
 
-            this.Validate(detectChangesOnChangeTracker: false);
+            await this.ValidateAsync(detectChangesOnChangeTracker: false, cancellationToken).ConfigureAwait(false);
         }
 
         protected virtual void EnrichMetadata()
@@ -108,10 +98,10 @@ namespace Nexplore.Practices.EntityFramework
             this.auditHistoryProvider.Value.CreateAuditHistory();
         }
 
-        protected virtual void Validate(bool detectChangesOnChangeTracker)
+        protected virtual async ValueTask ValidateAsync(bool detectChangesOnChangeTracker, CancellationToken cancellationToken)
         {
-            var validationResults = this.validationProvider.Value.Validate(detectChangesOnChangeTracker).ToArray();
-            if (validationResults.Length != 0)
+            var validationResults = await this.validationProvider.Value.ValidateAsync(detectChangesOnChangeTracker, cancellationToken).ConfigureAwait(false);
+            if (validationResults.Count != 0)
             {
                 throw new EntityValidationException(validationResults);
             }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWork.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWork.cs
@@ -19,11 +19,6 @@ namespace Nexplore.Practices.EntityFramework.Scopes
             this.lifetimeScope = lifetimeScope;
         }
 
-        public void SaveChanges()
-        {
-            this.context.SaveChanges();
-        }
-
         public Task SaveChangesAsync(CancellationToken cancellationToken)
         {
             return this.context.SaveChangesAsync(cancellationToken);

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWorkWithSingleDbTransaction.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Scopes/UnitOfWorkWithSingleDbTransaction.cs
@@ -19,11 +19,6 @@ namespace Nexplore.Practices.EntityFramework.Scopes
             this.transaction = transaction;
         }
 
-        public void CommitDbTransaction()
-        {
-            this.transaction.Commit();
-        }
-
         public async Task CommitDbTransactionAsync(CancellationToken cancellationToken)
         {
             await this.transaction.CommitAsync(cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Security/DataProtectionKeyRepository.cs
@@ -8,30 +8,39 @@ namespace Nexplore.Practices.EntityFramework.Security
     using Microsoft.AspNetCore.DataProtection.Repositories;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
-    using Nexplore.Practices.Core.Scopes;
+    using Microsoft.Extensions.Options;
+    using Nexplore.Practices.EntityFramework.Configuration;
 
     public class DataProtectionKeyRepository : IXmlRepository
     {
         private readonly ILogger<DataMisalignedException> logger;
-        private readonly IUnitOfWorkFactory<DbSet<DataProtectionKey>> unitOfWorkFactory;
+        private readonly IDbContextOptionsProvider contextOptionsProvider;
+        private readonly IDbModelCreator modelCreator;
+        private readonly IOptions<DatabaseOptions> databaseOptions;
 
-        public DataProtectionKeyRepository(ILogger<DataMisalignedException> logger, IUnitOfWorkFactory<DbSet<DataProtectionKey>> unitOfWorkFactory)
+        public DataProtectionKeyRepository(
+            ILogger<DataMisalignedException> logger,
+            IDbContextOptionsProvider contextOptionsProvider,
+            IDbModelCreator modelCreator,
+            IOptions<DatabaseOptions> databaseOptions)
         {
             this.logger = logger;
-            this.unitOfWorkFactory = unitOfWorkFactory;
+            this.contextOptionsProvider = contextOptionsProvider;
+            this.modelCreator = modelCreator;
+            this.databaseOptions = databaseOptions;
         }
 
         public virtual IReadOnlyCollection<XElement> GetAllElements()
         {
-            using (var unitOfWork = this.unitOfWorkFactory.Begin())
+            using (var dataContext = this.CreateDataProtectionContext())
             {
-                return unitOfWork.Dependent.AsNoTracking().Select(key => TryParseKeyXml(key.Xml, this.logger)).ToList().AsReadOnly();
+                return dataContext.Set<DataProtectionKey>().AsNoTracking().Select(key => TryParseKeyXml(key.Xml, this.logger)).ToList().AsReadOnly();
             }
         }
 
         public virtual void StoreElement(XElement element, string friendlyName)
         {
-            using (var unitOfWork = this.unitOfWorkFactory.Begin())
+            using (var dataContext = this.CreateDataProtectionContext())
             {
                 var newKey = new DataProtectionKey
                 {
@@ -39,9 +48,16 @@ namespace Nexplore.Practices.EntityFramework.Security
                     Xml = element.ToString(SaveOptions.DisableFormatting),
                 };
 
-                unitOfWork.Dependent.Add(newKey);
-                unitOfWork.SaveChanges();
+                dataContext.Set<DataProtectionKey>().Add(newKey);
+                dataContext.SaveChanges();
             }
+        }
+
+        protected virtual DbContext CreateDataProtectionContext()
+        {
+            var context = new DataProtectionDbContext(this.contextOptionsProvider, this.modelCreator);
+            context.ChangeTracker.AutoDetectChangesEnabled = this.databaseOptions.Value.AutoDetectChangesEnabled;
+            return context;
         }
 
         private static XElement TryParseKeyXml(string xml, ILogger logger)
@@ -54,6 +70,35 @@ namespace Nexplore.Practices.EntityFramework.Security
             {
                 logger?.LogError(exception, "Could not parse xml");
                 return null;
+            }
+        }
+
+        private sealed class DataProtectionDbContext : DbContext, IDataProtectionKeyContext
+        {
+            private readonly IDbContextOptionsProvider contextOptionsProvider;
+            private readonly IDbModelCreator modelCreator;
+
+            public DataProtectionDbContext(IDbContextOptionsProvider contextOptionsProvider, IDbModelCreator modelCreator)
+            {
+                this.contextOptionsProvider = contextOptionsProvider;
+                this.modelCreator = modelCreator;
+            }
+
+            public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                this.contextOptionsProvider.OnConfiguring(optionsBuilder);
+            }
+
+            protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+            {
+                this.modelCreator.ConfigureConventions(configurationBuilder);
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                this.modelCreator.OnModelCreating(modelBuilder);
             }
         }
     }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/IValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/IValidationProvider.cs
@@ -1,10 +1,12 @@
 namespace Nexplore.Practices.EntityFramework.Validation
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Nexplore.Practices.Core.Validation;
 
     public interface IValidationProvider
     {
-        IEnumerable<EntityValidationResult> Validate(bool detectChangesOnChangeTracker = true);
+        ValueTask<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default);
     }
 }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Validation/ValidationProvider.cs
@@ -6,6 +6,8 @@ namespace Nexplore.Practices.EntityFramework.Validation
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
     using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.ChangeTracking;
     using Microsoft.Extensions.Localization;
@@ -32,18 +34,18 @@ namespace Nexplore.Practices.EntityFramework.Validation
             this.validationLocalizer = stringLocalizerFactory.Create(typeof(ValidationResourceNames));
         }
 
-        public IEnumerable<EntityValidationResult> Validate(bool detectChangesOnChangeTracker = true)
+        public async ValueTask<IReadOnlyCollection<EntityValidationResult>> ValidateAsync(bool detectChangesOnChangeTracker = true, CancellationToken cancellationToken = default)
         {
             if (detectChangesOnChangeTracker)
             {
                 this.changeTracker.DetectChanges();
             }
 
-            var entriesToValidate = this.changeTracker.Entries<IValidatable<TValidationContext>>().Where(this.IsEntityEntryChanged).ToArray();
-            return this.ValidateMultipleEntities(entriesToValidate.Select(e => e.Entity));
+            var entriesToValidate = this.changeTracker.Entries<IValidatable>().Where(this.IsEntityEntryChanged).ToArray();
+            return await this.ValidateMultipleEntitiesAsync(entriesToValidate.Select(e => e.Entity), cancellationToken).ConfigureAwait(false);
         }
 
-        protected virtual bool IsEntityEntryChanged(EntityEntry<IValidatable<TValidationContext>> entry)
+        protected virtual bool IsEntityEntryChanged(EntityEntry<IValidatable> entry)
         {
             switch (entry.State)
             {
@@ -91,24 +93,42 @@ namespace Nexplore.Practices.EntityFramework.Validation
             return null;
         }
 
-        private IEnumerable<EntityValidationResult> ValidateMultipleEntities(IEnumerable<IValidatable<TValidationContext>> entities)
+        private async ValueTask<IReadOnlyCollection<EntityValidationResult>> ValidateMultipleEntitiesAsync(IEnumerable<IValidatable> entities, CancellationToken cancellationToken)
         {
-            return entities.Select(this.ValidateSingleEntity).Where(result => result != null);
-        }
+            var result = new List<EntityValidationResult>();
 
-        private EntityValidationResult ValidateSingleEntity(IValidatable<TValidationContext> entity)
-        {
-            var unitedValidationErrors = this.ValidateDataAnnotationAttributes(entity).Union(this.ValidateValidatable(entity)).ToArray();
-            if (unitedValidationErrors.Length == 0)
+            foreach (var validatable in entities)
             {
-                return null;
+                var validationResult = await this.ValidateSingleEntityAsync(validatable, cancellationToken).ConfigureAwait(false);
+                if (validationResult != null)
+                {
+                    result.Add(validationResult);
+                }
             }
 
-            var validationErrors = new ReadOnlyCollection<EntityValidationError>(unitedValidationErrors);
-            return new EntityValidationResult(entity, validationErrors);
+            return result;
         }
 
-        private IEnumerable<EntityValidationError> ValidateDataAnnotationAttributes(IValidatable<TValidationContext> entity)
+        private async ValueTask<EntityValidationResult> ValidateSingleEntityAsync(IValidatable entity, CancellationToken cancellationToken)
+        {
+            var validationErrors = new List<EntityValidationError>();
+
+            validationErrors.AddRange(this.ValidateDataAnnotationAttributes(entity));
+
+            if (entity is IValidatable<TValidationContext> syncValidatable)
+            {
+                validationErrors.AddRange(syncValidatable.Validate(this.validationContext));
+            }
+
+            if (entity is IAsyncValidatable<TValidationContext> asyncValidatable)
+            {
+                validationErrors.AddRange(await asyncValidatable.ValidateAsync(this.validationContext, cancellationToken).ConfigureAwait(false));
+            }
+
+            return validationErrors.Count == 0 ? null : new EntityValidationResult(entity, validationErrors);
+        }
+
+        private IEnumerable<EntityValidationError> ValidateDataAnnotationAttributes(IValidatable entity)
         {
             var dataAnnotationValidationContext = new ValidationContext(entity);
             var dataAnnotationResults = new Collection<ValidationResult>();
@@ -124,11 +144,6 @@ namespace Nexplore.Practices.EntityFramework.Validation
 
                 yield return new EntityValidationError(errorMessage, dataAnnotationResult.MemberNames.Single());
             }
-        }
-
-        private IEnumerable<EntityValidationError> ValidateValidatable(IValidatable<TValidationContext> entity)
-        {
-            return entity.Validate(this.validationContext);
         }
     }
 }

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/Bootstrap/Domain/EntityBase.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/Bootstrap/Domain/EntityBase.cs
@@ -2,20 +2,16 @@ namespace Nexplore.Practices.Tests.Integration.Bootstrap.Domain
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Nexplore.Practices.Core.Domain.Model;
     using Nexplore.Practices.Core.Domain.Model.Audit;
     using Nexplore.Practices.Core.Validation;
     using Nexplore.Practices.Tests.Integration.Bootstrap.Validation;
 
-    public abstract class EntityBase : IEntity<Guid>, ITimestamped, IModificationMetadata, IValidatable<IValidationContext>, IAuditable
+    public abstract class EntityBase : IEntity<Guid>, ITimestamped, IModificationMetadata, IValidatable<IValidationContext>, IAsyncValidatable<IValidationContext>, IAuditable
     {
-        protected EntityBase()
-        {
-            this.Id = Guid.NewGuid();
-        }
-
-        public Guid Id { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
 
         public string CreatedBy { get; set; }
 
@@ -33,7 +29,12 @@ namespace Nexplore.Practices.Tests.Integration.Bootstrap.Domain
 
         public IEnumerable<EntityValidationError> Validate(IValidationContext context)
         {
-            return Enumerable.Empty<EntityValidationError>();
+            yield break;
+        }
+
+        public Task<IReadOnlyCollection<EntityValidationError>> ValidateAsync(IValidationContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult((IReadOnlyCollection<EntityValidationError>)[]);
         }
 
         public string GetAuditKey()

--- a/dotnet/tests/Nexplore.Practices.Tests.Integration/EntityFramework/UnitOfWorkFactoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Integration/EntityFramework/UnitOfWorkFactoryTests.cs
@@ -42,7 +42,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         {
             // Arrange
             var entityId = Guid.Empty;
-            using (var unitOfWork = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var unitOfWork = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 var entity = unitOfWork.Dependent.Create();
                 entity.FirstName = "Test Firstname";
@@ -70,7 +70,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         {
             // Arrange
             var entityId = Guid.Empty;
-            using (var unitOfWork = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var unitOfWork = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 var entity = unitOfWork.Dependent.Create();
                 entity.FirstName = "Test Firstname";
@@ -80,7 +80,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
 
                 // Act
                 await unitOfWork.SaveChangesAsync();
-                unitOfWork.CommitDbTransaction();
+                await unitOfWork.CommitDbTransactionAsync();
 
                 entityId = entity.Id;
             }
@@ -100,7 +100,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         [Test]
         public async Task BeginWithSingleDbTransaction_WithChildUnitOfWork_ShareTransaction()
         {
-            using (var superUnit = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var superUnit = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 // Arrange
                 var entityId = Guid.Empty;
@@ -128,7 +128,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
                     Assert.That(entity.LastName, Is.EqualTo("Test Lastname"));
                 }
 
-                superUnit.CommitDbTransaction();
+                await superUnit.CommitDbTransactionAsync();
             }
         }
 
@@ -136,8 +136,8 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
         public async Task BeginWithSingleDbTransaction_InSeparatedUnitOfWorks_AreIsolatedUntilCommitDbTransaction()
         {
             // Arrange
-            using (var leftUnit = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
-            using (var rightUnit = this.unitOfWorkFactory.BeginWithSingleDbTransaction())
+            using (var leftUnit = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
+            using (var rightUnit = await this.unitOfWorkFactory.BeginWithSingleDbTransactionAsync())
             {
                 var entity = leftUnit.Dependent.Create();
                 entity.FirstName = "Test Firstname";
@@ -155,7 +155,7 @@ namespace Nexplore.Practices.Tests.Integration.EntityFramework
                 Assert.That(rightEntityTry, Is.Null);
 
                 // Act
-                leftUnit.CommitDbTransaction();
+                await leftUnit.CommitDbTransactionAsync();
 
                 // Assert
                 var rightEntitySecondTry = await rightUnit.Dependent.GetByIdOrDefaultAsync(entityId);

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/EntityFramework/Security/DataProtectionKeyRepositoryTests.cs
@@ -1,0 +1,89 @@
+namespace Nexplore.Practices.Tests.Unit.EntityFramework.Security
+{
+    using System;
+    using System.Xml.Linq;
+    using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Extensions.Options;
+    using Nexplore.Practices.EntityFramework.Configuration;
+    using Nexplore.Practices.EntityFramework.Security;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DataProtectionKeyRepositoryTests
+    {
+        [Test]
+        public void StoreElement_WithPlainDataProtectionContext_PersistsKeySynchronously()
+        {
+            // Arrange
+            var databaseName = Guid.NewGuid().ToString();
+            var contextOptionsProvider = new InMemoryContextOptionsProvider(databaseName);
+            var modelCreator = new DataProtectionTestModelCreator();
+            var repository = new DataProtectionKeyRepository(
+                NullLogger<DataMisalignedException>.Instance,
+                contextOptionsProvider,
+                modelCreator,
+                Options.Create(new DatabaseOptions()));
+            var element = XElement.Parse("<key id=\"test-key\" />");
+
+            // Act
+            repository.StoreElement(element, "test-friendly-name");
+
+            // Assert
+            using (var dataContext = CreateDataProtectionContext(databaseName))
+            {
+                var key = dataContext.Set<DataProtectionKey>().SingleAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+
+                Assert.That(key.FriendlyName, Is.EqualTo("test-friendly-name"));
+                Assert.That(key.Xml, Is.EqualTo(element.ToString(SaveOptions.DisableFormatting)));
+            }
+        }
+
+        private static TestDataProtectionContext CreateDataProtectionContext(string databaseName)
+        {
+            var options = new DbContextOptionsBuilder<TestDataProtectionContext>()
+                .UseInMemoryDatabase(databaseName)
+                .Options;
+
+            return new TestDataProtectionContext(options);
+        }
+
+        private sealed class InMemoryContextOptionsProvider : IDbContextOptionsProvider
+        {
+            private readonly string databaseName;
+
+            public InMemoryContextOptionsProvider(string databaseName)
+            {
+                this.databaseName = databaseName;
+            }
+
+            public void OnConfiguring(DbContextOptionsBuilder builder)
+            {
+                builder.UseInMemoryDatabase(this.databaseName);
+            }
+        }
+
+        private sealed class DataProtectionTestModelCreator : IDbModelCreator
+        {
+            public void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+            {
+            }
+
+            public void OnModelCreating(ModelBuilder builder)
+            {
+                builder.Entity<DataProtectionKey>();
+            }
+        }
+
+        private sealed class TestDataProtectionContext : DbContext, IDataProtectionKeyContext
+        {
+            public TestDataProtectionContext(DbContextOptions<TestDataProtectionContext> options)
+                : base(options)
+            {
+            }
+
+            public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+        }
+    }
+}

--- a/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
+++ b/dotnet/tests/Nexplore.Practices.Tests.Unit/Nexplore.Practices.Tests.Unit.csproj
@@ -6,14 +6,17 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.15" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.15" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ng/practices-ui-ktbe/.storybook/main.ts
+++ b/ng/practices-ui-ktbe/.storybook/main.ts
@@ -4,5 +4,6 @@ import mainRoot from '../../.storybook/main';
 const config: StorybookConfig = {
     ...mainRoot,
     stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+    staticDirs: [...(mainRoot.staticDirs ?? []), { from: '../../samples-ktbe/src/assets', to: '/assets' }],
 };
 export default config;

--- a/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
+++ b/ng/practices-ui-ktbe/src/lib/tooltip/tooltip.component.html
@@ -1,4 +1,5 @@
 <button
+    type="button"
     cdkOverlayOrigin
     class="text-small leading-ktbe-small select-none rounded-full border bg-white px-[5px] py-0 font-bold transition-all duration-200 ease-in-out hover:scale-[1.2]"
     (click)="toggle()"

--- a/ng/samples-ktbe/tailwind.config.js
+++ b/ng/samples-ktbe/tailwind.config.js
@@ -1,8 +1,12 @@
 /** @type {import('tailwindcss').Config} **/
 
+const path = require('path');
 const ktbeTheme = require('../practices-ui-ktbe/tailwind.config.js');
 
 module.exports = {
-    content: ['./practices-ui-ktbe/src/**/*.{html,ts}', './samples-ktbe/src/**/*.{html,ts}'],
+    content: [
+        path.resolve(__dirname, '../practices-ui-ktbe/src/**/*.{html,ts}'),
+        path.resolve(__dirname, './src/**/*.{html,ts}'),
+    ],
     presets: [ktbeTheme],
 };


### PR DESCRIPTION
## Description

This maintenance branch synchronizes the Tailwind library line with the latest `main` changes. It carries the async-validation API and persistence fixes from #36, the KTBE tooltip form-submit fix from #55, and the KTBE Storybook Tailwind/font asset fixes from #33. The only merge conflict was in the deprecated `CHANGELOG.md`; the existing unreleased feature entries were retained and the duplicated historical block was removed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Local full clone: `main` vs `feature/tailwind-4-new-library` was 3 commits ahead / 48 behind, with merge base `e56c3bf`.
- `git merge-tree --write-tree` initially reported only the intentional `CHANGELOG.md` conflict.
- Resolved candidate commit has parents `623a7dc` (feature branch) and `1146196` (current `main`), with connector tree `0b20199` matching the local merge tree.
- `git diff --check origin/feature/tailwind-4-new-library...HEAD` passed locally.
- GitHub Actions Build & Test run 247 passed on head `1f87dbd`: https://github.com/nexplore/nexplore-practices/actions/runs/29282591404
- The Build & Test job completed `./build.sh BuildPackAll`, artifact upload, and cleanup successfully.
- No local .NET build/test was run because the required .NET toolchain is unavailable.

## Integration Instructions

Merge this draft into `feature/tailwind-4-new-library` after maintainer review.