### PR TITLE
`Nexplore.Practices.EntityFramework` Made `QuerySplittingBehavior` configurable (SingleQuery stays the default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Nexplore.Practices.EntityFramework` Made `QuerySplittingBehaviour` configurable (SingleQuery stays the default)
+
+## [12.0.0](https://github.com/nexplore/nexplore-practices/releases/tag/12.0.0) - 2026-06-24
+
 ### Added
 
 - `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Configuration/DatabaseOptions.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Configuration/DatabaseOptions.cs
@@ -1,5 +1,7 @@
 namespace Nexplore.Practices.EntityFramework.Configuration
 {
+    using Microsoft.EntityFrameworkCore;
+
     public class DatabaseOptions
     {
         public const string NAME = "Database";
@@ -23,5 +25,7 @@ namespace Nexplore.Practices.EntityFramework.Configuration
         public string DataProtectionEncryptionPassword { get; set; }
 
         public bool AutoDetectChangesEnabled { get; set; } = true;
+
+        public QuerySplittingBehavior QuerySplittingBehavior { get; set; } = QuerySplittingBehavior.SingleQuery;
     }
 }

--- a/dotnet/src/Nexplore.Practices.EntityFramework/Configuration/DbContextOptionsProvider.cs
+++ b/dotnet/src/Nexplore.Practices.EntityFramework/Configuration/DbContextOptionsProvider.cs
@@ -53,8 +53,8 @@ namespace Nexplore.Practices.EntityFramework.Configuration
             var historySchema = this.options.Value.MigrationHistorySchema;
 
             builder.MigrationsHistoryTable(historyTable, historySchema);
-
             builder.MigrationsAssembly(this.options.Value.MigrationAssembly);
+            builder.UseQuerySplittingBehavior(this.options.Value.QuerySplittingBehavior);
         }
 
         protected virtual void ConfigureInterceptors(DbContextOptionsBuilder builder)


### PR DESCRIPTION
## Description

Make QuerySplittingBehavior configurable in DataBaseOptions.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## Integration Instructions

Configure in appsettings.json:
```json
{
  "Database": {
    "QuerySplittingBehavior": "SingleQuery | SplitQuery",
    [...]
  }
}
```