### PR TITLE
practices-ui-ktbe: fix long labels overlapping input and optional badge

### DIFF
--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.html
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!(isReadonly$ | async); else readonly" class="relative mt-5">
+<div *ngIf="!(isReadonly$ | async); else readonly" class="relative">
     <ng-content select="label[puibeLabel]"></ng-content>
     <div
         *ngIf="overlayTextValue$ | async as overlayTextValue"
@@ -62,6 +62,7 @@
         } as context"
     >
         <span
+            #optionalBadge
             class="text-very-small absolute -top-5 z-10 translate-y-2 rounded-lg bg-white px-1 py-0.5"
             [ngClass]="{ 'right-[75px]': context.isCustomIconFilled, 'right-3': !context.isCustomIconFilled }"
             [class.text-red]="context.displayAsInvalid"
@@ -89,7 +90,7 @@
     <ng-content></ng-content>
 </div>
 <ng-template #readonly>
-    <puibe-readonly-label-value [label]="labelString" [useSmallLabel]="useSmallTextForReadonlyLabel">
+    <puibe-readonly-label-value [label]="labelStringSignal()" [useSmallLabel]="useSmallTextForReadonlyLabel">
         <ng-container *ngIf="ngControlValue$ | async as value; else noEntry">
             <ng-container *ngIf="value || value === 0; else noEntry">
                 <ng-content select="[slot='readonly-prefix']"/>

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -77,8 +77,8 @@ const overlayTextEmptyClassName = 'text-opacity-60';
     },
 })
 export class PuibeFormFieldComponent {
-    isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
-    readonly ngControlValue$ = this._formFieldService.readonlyValue$;
+    public readonly isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
+    public readonly ngControlValue$ = this._formFieldService.readonlyValue$;
 
     private readonly _hideOptionalSubject = new BehaviorSubject<boolean>(false);
     private readonly _inputEvent$ = this._formFieldService.element$.pipe(
@@ -87,77 +87,77 @@ export class PuibeFormFieldComponent {
     );
 
     @Input()
-    useSmallTextForReadonlyLabel: boolean | null = null;
+    public useSmallTextForReadonlyLabel: boolean | null = null;
 
     @Input()
-    set hideOptional(value: boolean) {
+    public set hideOptional(value: boolean) {
         this._hideOptionalSubject.next(value);
     }
 
     @Input()
-    readonlyEmptyValuePlaceholder: string;
+    public readonlyEmptyValuePlaceholder: string;
 
-    readonly labelSignal = contentChild(PuibeLabelDirective);
+    public readonly labelSignal = contentChild(PuibeLabelDirective);
 
-    get label(): PuibeLabelDirective | undefined {
+    public get label(): PuibeLabelDirective | undefined {
         return this.labelSignal();
     }
 
-    readonly optionalBadgeSignal = viewChild<ElementRef<HTMLElement>>('optionalBadge');
+    private readonly _optionalBadgeSignal = viewChild<ElementRef<HTMLElement>>('optionalBadge');
 
     private readonly _labelStringSignal = signal('');
     protected readonly labelStringSignal = this._labelStringSignal.asReadonly();
 
-    id$ = this._formFieldService.id$;
-    isOptional$ = this._formFieldService.isRequired$.pipe(
+    public id$ = this._formFieldService.id$;
+    public isOptional$ = this._formFieldService.isRequired$.pipe(
         combineLatestWith(this._hideOptionalSubject),
         map(([isRequired, hideOptional]) => !isRequired && !hideOptional)
     );
-    invalid$ = this._formFieldService.status$.pipe(map((status) => status === 'INVALID'));
-    displayAsInvalid$ = this._formFieldService.displayAsInvalid$;
-    disabled$ = this._formFieldService.status$.pipe(map((status) => status === 'DISABLED'));
-    pending$ = this._formFieldService.status$.pipe(
+    public invalid$ = this._formFieldService.status$.pipe(map((status) => status === 'INVALID'));
+    public displayAsInvalid$ = this._formFieldService.displayAsInvalid$;
+    public disabled$ = this._formFieldService.status$.pipe(map((status) => status === 'DISABLED'));
+    public pending$ = this._formFieldService.status$.pipe(
         combineLatestWith(this._formFieldService.loading$),
         map(([status, loading]) => status === 'PENDING' || loading === true)
     );
 
-    iconComponent$ = this._formFieldService.icon$.pipe(map((cf) => cf?.component));
+    public iconComponent$ = this._formFieldService.icon$.pipe(map((cf) => cf?.component));
 
-    showCustomIcon$ = this._formFieldService.icon$.pipe(
+    public showCustomIcon$ = this._formFieldService.icon$.pipe(
         combineLatestWith(this.invalid$, this.pending$),
         map(([cf, invalid, pending]) => cf && (cf.showOnlyIfValid ? !invalid && !pending : true))
     );
 
-    iconClickable$ = this._formFieldService.icon$.pipe(
+    public iconClickable$ = this._formFieldService.icon$.pipe(
         combineLatestWith(this.showCustomIcon$, this.disabled$),
         map(([cf, showCustomIcon, disabled]) => showCustomIcon && !disabled && cf && cf.clickable)
     );
 
-    isClearable$ = this._formFieldService.clearable$.pipe(
+    public isClearable$ = this._formFieldService.clearable$.pipe(
         combineLatestWith(this.disabled$),
         map(([clearable, disabled]) => clearable && !disabled)
     );
 
-    iconClassName = iconDefaultClassName;
+    public iconClassName = iconDefaultClassName;
 
-    isCustomIconFilled$ = this._formFieldService.icon$.pipe(map((cf) => cf?.fill));
+    public isCustomIconFilled$ = this._formFieldService.icon$.pipe(map((cf) => cf?.fill));
 
-    customIconClassName$ = this._formFieldService.icon$.pipe(
+    public customIconClassName$ = this._formFieldService.icon$.pipe(
         combineLatestWith(this.showCustomIcon$, this.displayAsInvalid$, this.disabled$),
         map(([cf, canShow, displayAsInvalid, disabled]) =>
             canShow && cf ? this._getCustomIconClassName(displayAsInvalid, disabled, cf) : ''
         )
     );
 
-    customIconClickable$ = this._formFieldService.icon$.pipe(map((icon) => icon?.clickable));
+    public customIconClickable$ = this._formFieldService.icon$.pipe(map((icon) => icon?.clickable));
 
-    customIconTitle$ = this._formFieldService.icon$.pipe(map((icon) => icon?.title));
+    public customIconTitle$ = this._formFieldService.icon$.pipe(map((icon) => icon?.title));
 
-    overlayTextValue$ = this._formFieldService.overlayText$.pipe(map((cf) => cf?.text));
+    public overlayTextValue$ = this._formFieldService.overlayText$.pipe(map((cf) => cf?.text));
 
-    ariaDescription$ = this._formFieldService.ariaDescription$;
+    public ariaDescription$ = this._formFieldService.ariaDescription$;
 
-    overlayTextClassName$ = combineLatest([
+    public overlayTextClassName$ = combineLatest([
         this._formFieldService.overlayText$,
         this._formFieldService.value$,
         this.displayAsInvalid$,
@@ -168,11 +168,13 @@ export class PuibeFormFieldComponent {
         )
     );
 
-    iconContainerClassName$ = combineLatest([this.displayAsInvalid$, this.customIconClickable$, this.disabled$]).pipe(
-        map(([invalid, clickable, disabled]) => this._getIconContainerClassName(invalid, clickable, disabled))
-    );
+    public iconContainerClassName$ = combineLatest([
+        this.displayAsInvalid$,
+        this.customIconClickable$,
+        this.disabled$,
+    ]).pipe(map(([invalid, clickable, disabled]) => this._getIconContainerClassName(invalid, clickable, disabled)));
 
-    errors$ = this._formFieldService.errors$.pipe(
+    public errors$ = this._formFieldService.errors$.pipe(
         map((errors) => {
             if (errors == null) {
                 return [];
@@ -187,13 +189,13 @@ export class PuibeFormFieldComponent {
         })
     );
 
-    readonly dirty$ = this._formFieldService.dirty$;
-    readonly touched$ = this._formFieldService.touched$;
+    public readonly dirty$ = this._formFieldService.dirty$;
+    public readonly touched$ = this._formFieldService.touched$;
 
     /**
      * Returns true if the label should be shown above the form field, while the field has a value or if has a custom placeholder
      */
-    readonly shouldShowLabelAboveField$ = combineLatest([
+    public readonly shouldShowLabelAboveField$ = combineLatest([
         this._formFieldService.value$.pipe(startWith(null)),
         this._inputEvent$.pipe(startWith(null)),
         this._formFieldService.placeholder$,
@@ -236,7 +238,7 @@ export class PuibeFormFieldComponent {
         });
 
         effect((onCleanup) => {
-            const badge = this.optionalBadgeSignal()?.nativeElement;
+            const badge = this._optionalBadgeSignal()?.nativeElement;
             const label = this.labelSignal();
             if (!badge || !label) {
                 label?.setBoundaryRight(null);
@@ -252,7 +254,7 @@ export class PuibeFormFieldComponent {
         });
     }
 
-    onClear() {
+    public onClear() {
         this.isClearable$.pipe(take(1)).subscribe((clearable) => {
             if (clearable) {
                 this._formFieldService.emitClear();
@@ -260,7 +262,7 @@ export class PuibeFormFieldComponent {
         });
     }
 
-    onIconClick(event: MouseEvent) {
+    public onIconClick(event: MouseEvent) {
         this.iconClickable$.pipe(take(1)).subscribe((clickable) => {
             if (clickable) {
                 this._formFieldService.emitIconClick(event);

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -77,7 +77,7 @@ const overlayTextEmptyClassName = 'text-opacity-60';
     },
 })
 export class PuibeFormFieldComponent {
-    readonly isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
+    isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
     readonly ngControlValue$ = this._formFieldService.readonlyValue$;
 
     private readonly _hideOptionalSubject = new BehaviorSubject<boolean>(false);

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -6,8 +6,8 @@ import {
     contentChild,
     effect,
     ElementRef,
+    inject,
     Input,
-    Optional,
     signal,
     viewChild,
 } from '@angular/core';
@@ -77,6 +77,10 @@ const overlayTextEmptyClassName = 'text-opacity-60';
     },
 })
 export class PuibeFormFieldComponent {
+    private readonly _formFieldService = inject(FormFieldService);
+    private readonly _readonlyDirective = inject(PuibeReadonlyDirective, { optional: true })
+    private readonly _elementRef = inject(ElementRef<HTMLElement>);
+
     isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
     readonly ngControlValue$ = this._formFieldService.readonlyValue$;
 
@@ -95,12 +99,12 @@ export class PuibeFormFieldComponent {
     }
 
     @Input()
-    readonlyEmptyValuePlaceholder: string;
+    readonlyEmptyValuePlaceholder: string | null = null;
 
-    protected readonly labelSignal = contentChild(PuibeLabelDirective);
+    private readonly _labelSignal = contentChild(PuibeLabelDirective);
 
     get label(): PuibeLabelDirective | undefined {
-        return this.labelSignal();
+        return this._labelSignal();
     }
 
     private readonly _optionalBadgeSignal = viewChild<ElementRef<HTMLElement>>('optionalBadge');
@@ -219,40 +223,36 @@ export class PuibeFormFieldComponent {
         initialValue: false,
     });
     protected readonly hostPaddingTopSignal = computed(() => {
-        const label = this.labelSignal();
+        const label = this._labelSignal();
         if (!label) {
-            return '';
+            return `${fieldTopSpacingPx}px`;
         }
-        const floating = !!this._shouldShowLabelAboveFieldSignal() || label.alwaysVisibleSignal();
-        const reserved = floating ? Math.max(fieldTopSpacingPx, label.heightSignal()) : fieldTopSpacingPx;
-        return `${reserved}px`;
+
+        const reservedTopSpacingPx = Math.max(fieldTopSpacingPx, label.heightSignal());
+        return `${reservedTopSpacingPx}px`;
     });
 
-    constructor(
-        private _formFieldService: FormFieldService,
-        private readonly _elementRef: ElementRef<HTMLElement>,
-        @Optional() private readonly _readonlyDirective: PuibeReadonlyDirective
-    ) {
+    constructor() {
         effect(() => {
-            const label = this.labelSignal();
+            const label = this._labelSignal();
             if (label) {
                 this._labelStringSignal.set(label.labelTextSignal());
             }
         });
 
         effect(() => {
-            this.labelSignal()?.setShouldShowAbove(!!this._shouldShowLabelAboveFieldSignal());
+            this._labelSignal()?.setShouldShowAboveField(!!this._shouldShowLabelAboveFieldSignal());
         });
 
         effect((onCleanup) => {
             const badge = this._optionalBadgeSignal()?.nativeElement;
-            const label = this.labelSignal();
+            const label = this._labelSignal();
             if (!badge || !label) {
-                label?.setBoundaryRight(null);
+                label?.setRightBoundary(null);
                 return;
             }
 
-            const update = () => label.setBoundaryRight(badge.offsetLeft - labelBadgeGapPx);
+            const update = () => label.setRightBoundary(badge.offsetLeft - labelBadgeGapPx);
             update();
 
             const observer = new ResizeObserver(update);

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -77,8 +77,8 @@ const overlayTextEmptyClassName = 'text-opacity-60';
     },
 })
 export class PuibeFormFieldComponent {
-    public readonly isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
-    public readonly ngControlValue$ = this._formFieldService.readonlyValue$;
+    readonly isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
+    readonly ngControlValue$ = this._formFieldService.readonlyValue$;
 
     private readonly _hideOptionalSubject = new BehaviorSubject<boolean>(false);
     private readonly _inputEvent$ = this._formFieldService.element$.pipe(
@@ -87,19 +87,19 @@ export class PuibeFormFieldComponent {
     );
 
     @Input()
-    public useSmallTextForReadonlyLabel: boolean | null = null;
+    useSmallTextForReadonlyLabel: boolean | null = null;
 
     @Input()
-    public set hideOptional(value: boolean) {
+    set hideOptional(value: boolean) {
         this._hideOptionalSubject.next(value);
     }
 
     @Input()
-    public readonlyEmptyValuePlaceholder: string;
+    readonlyEmptyValuePlaceholder: string;
 
     protected readonly labelSignal = contentChild(PuibeLabelDirective);
 
-    public get label(): PuibeLabelDirective | undefined {
+    get label(): PuibeLabelDirective | undefined {
         return this.labelSignal();
     }
 
@@ -111,60 +111,60 @@ export class PuibeFormFieldComponent {
     /**
      * @deprecated Use {@link labelStringSignal} instead. Kept for backwards compatibility.
      */
-    public get labelString(): string {
+    get labelString(): string {
         return this._labelStringSignal();
     }
 
-    public id$ = this._formFieldService.id$;
-    public isOptional$ = this._formFieldService.isRequired$.pipe(
+    id$ = this._formFieldService.id$;
+    isOptional$ = this._formFieldService.isRequired$.pipe(
         combineLatestWith(this._hideOptionalSubject),
         map(([isRequired, hideOptional]) => !isRequired && !hideOptional)
     );
-    public invalid$ = this._formFieldService.status$.pipe(map((status) => status === 'INVALID'));
-    public displayAsInvalid$ = this._formFieldService.displayAsInvalid$;
-    public disabled$ = this._formFieldService.status$.pipe(map((status) => status === 'DISABLED'));
-    public pending$ = this._formFieldService.status$.pipe(
+    invalid$ = this._formFieldService.status$.pipe(map((status) => status === 'INVALID'));
+    displayAsInvalid$ = this._formFieldService.displayAsInvalid$;
+    disabled$ = this._formFieldService.status$.pipe(map((status) => status === 'DISABLED'));
+    pending$ = this._formFieldService.status$.pipe(
         combineLatestWith(this._formFieldService.loading$),
         map(([status, loading]) => status === 'PENDING' || loading === true)
     );
 
-    public iconComponent$ = this._formFieldService.icon$.pipe(map((cf) => cf?.component));
+    iconComponent$ = this._formFieldService.icon$.pipe(map((cf) => cf?.component));
 
-    public showCustomIcon$ = this._formFieldService.icon$.pipe(
+    showCustomIcon$ = this._formFieldService.icon$.pipe(
         combineLatestWith(this.invalid$, this.pending$),
         map(([cf, invalid, pending]) => cf && (cf.showOnlyIfValid ? !invalid && !pending : true))
     );
 
-    public iconClickable$ = this._formFieldService.icon$.pipe(
+    iconClickable$ = this._formFieldService.icon$.pipe(
         combineLatestWith(this.showCustomIcon$, this.disabled$),
         map(([cf, showCustomIcon, disabled]) => showCustomIcon && !disabled && cf && cf.clickable)
     );
 
-    public isClearable$ = this._formFieldService.clearable$.pipe(
+    isClearable$ = this._formFieldService.clearable$.pipe(
         combineLatestWith(this.disabled$),
         map(([clearable, disabled]) => clearable && !disabled)
     );
 
-    public iconClassName = iconDefaultClassName;
+    iconClassName = iconDefaultClassName;
 
-    public isCustomIconFilled$ = this._formFieldService.icon$.pipe(map((cf) => cf?.fill));
+    isCustomIconFilled$ = this._formFieldService.icon$.pipe(map((cf) => cf?.fill));
 
-    public customIconClassName$ = this._formFieldService.icon$.pipe(
+    customIconClassName$ = this._formFieldService.icon$.pipe(
         combineLatestWith(this.showCustomIcon$, this.displayAsInvalid$, this.disabled$),
         map(([cf, canShow, displayAsInvalid, disabled]) =>
             canShow && cf ? this._getCustomIconClassName(displayAsInvalid, disabled, cf) : ''
         )
     );
 
-    public customIconClickable$ = this._formFieldService.icon$.pipe(map((icon) => icon?.clickable));
+    customIconClickable$ = this._formFieldService.icon$.pipe(map((icon) => icon?.clickable));
 
-    public customIconTitle$ = this._formFieldService.icon$.pipe(map((icon) => icon?.title));
+    customIconTitle$ = this._formFieldService.icon$.pipe(map((icon) => icon?.title));
 
-    public overlayTextValue$ = this._formFieldService.overlayText$.pipe(map((cf) => cf?.text));
+    overlayTextValue$ = this._formFieldService.overlayText$.pipe(map((cf) => cf?.text));
 
-    public ariaDescription$ = this._formFieldService.ariaDescription$;
+    ariaDescription$ = this._formFieldService.ariaDescription$;
 
-    public overlayTextClassName$ = combineLatest([
+    overlayTextClassName$ = combineLatest([
         this._formFieldService.overlayText$,
         this._formFieldService.value$,
         this.displayAsInvalid$,
@@ -175,13 +175,13 @@ export class PuibeFormFieldComponent {
         )
     );
 
-    public iconContainerClassName$ = combineLatest([
+    iconContainerClassName$ = combineLatest([
         this.displayAsInvalid$,
         this.customIconClickable$,
         this.disabled$,
     ]).pipe(map(([invalid, clickable, disabled]) => this._getIconContainerClassName(invalid, clickable, disabled)));
 
-    public errors$ = this._formFieldService.errors$.pipe(
+    errors$ = this._formFieldService.errors$.pipe(
         map((errors) => {
             if (errors == null) {
                 return [];
@@ -196,13 +196,13 @@ export class PuibeFormFieldComponent {
         })
     );
 
-    public readonly dirty$ = this._formFieldService.dirty$;
-    public readonly touched$ = this._formFieldService.touched$;
+    readonly dirty$ = this._formFieldService.dirty$;
+    readonly touched$ = this._formFieldService.touched$;
 
     /**
      * Returns true if the label should be shown above the form field, while the field has a value or if has a custom placeholder
      */
-    public readonly shouldShowLabelAboveField$ = combineLatest([
+    readonly shouldShowLabelAboveField$ = combineLatest([
         this._formFieldService.value$.pipe(startWith(null)),
         this._inputEvent$.pipe(startWith(null)),
         this._formFieldService.placeholder$,
@@ -261,7 +261,7 @@ export class PuibeFormFieldComponent {
         });
     }
 
-    public onClear() {
+    onClear() {
         this.isClearable$.pipe(take(1)).subscribe((clearable) => {
             if (clearable) {
                 this._formFieldService.emitClear();
@@ -269,7 +269,7 @@ export class PuibeFormFieldComponent {
         });
     }
 
-    public onIconClick(event: MouseEvent) {
+    onIconClick(event: MouseEvent) {
         this.iconClickable$.pipe(take(1)).subscribe((clickable) => {
             if (clickable) {
                 this._formFieldService.emitIconClick(event);

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -1,13 +1,17 @@
 import { AsyncPipe, NgClass, NgComponentOutlet, NgFor, NgIf } from '@angular/common';
 import {
-    AfterViewInit,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    HostBinding,
+    computed,
+    contentChild,
+    effect,
+    ElementRef,
     Input,
     Optional,
+    signal,
+    viewChild,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { PuiFormFieldDirective } from '@nexplore/practices-ng-forms';
 import { TranslateModule } from '@ngx-translate/core';
 import {
@@ -32,6 +36,8 @@ import { FormFieldIconConfig, FormFieldService } from './form-field.service';
 import { PuibeLabelDirective } from './label.directive';
 
 const className = 'block';
+const fieldTopSpacingPx = 20;
+const labelBadgeGapPx = 8;
 
 const iconContainerDefaultClassName = 'absolute right-[2px] top-[2px] z-10 flex h-[56px] items-center';
 const iconDefaultClassName = 'h-8 w-8 mb-[2px] mr-4';
@@ -65,10 +71,13 @@ const overlayTextEmptyClassName = 'text-opacity-60';
     selector: 'puibe-form-field',
     standalone: true,
     templateUrl: './form-field.component.html',
+    host: {
+        class: className,
+        '[style.padding-top]': 'hostPaddingTopSignal()',
+    },
 })
-export class PuibeFormFieldComponent implements AfterViewInit {
+export class PuibeFormFieldComponent {
     isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
-    labelString: string;
     readonly ngControlValue$ = this._formFieldService.readonlyValue$;
 
     private readonly _hideOptionalSubject = new BehaviorSubject<boolean>(false);
@@ -88,10 +97,16 @@ export class PuibeFormFieldComponent implements AfterViewInit {
     @Input()
     readonlyEmptyValuePlaceholder: string;
 
-    @ContentChild(PuibeLabelDirective) label: PuibeLabelDirective;
+    readonly labelSignal = contentChild(PuibeLabelDirective);
 
-    @HostBinding('class')
-    className = className;
+    get label(): PuibeLabelDirective | undefined {
+        return this.labelSignal();
+    }
+
+    readonly optionalBadgeSignal = viewChild<ElementRef<HTMLElement>>('optionalBadge');
+
+    private readonly _labelStringSignal = signal('');
+    protected readonly labelStringSignal = this._labelStringSignal.asReadonly();
 
     id$ = this._formFieldService.id$;
     isOptional$ = this._formFieldService.isRequired$.pipe(
@@ -191,13 +206,50 @@ export class PuibeFormFieldComponent implements AfterViewInit {
         shareReplay({ refCount: true, bufferSize: 1 })
     );
 
+    private readonly _shouldShowLabelAboveFieldSignal = toSignal(this.shouldShowLabelAboveField$, {
+        initialValue: false,
+    });
+    protected readonly hostPaddingTopSignal = computed(() => {
+        const label = this.labelSignal();
+        if (!label) {
+            return '';
+        }
+        const floating = !!this._shouldShowLabelAboveFieldSignal() || label.alwaysVisibleSignal();
+        const reserved = floating ? Math.max(fieldTopSpacingPx, label.heightSignal()) : fieldTopSpacingPx;
+        return `${reserved}px`;
+    });
+
     constructor(
         private _formFieldService: FormFieldService,
+        private readonly _elementRef: ElementRef<HTMLElement>,
         @Optional() private readonly _readonlyDirective: PuibeReadonlyDirective
-    ) {}
+    ) {
+        effect(() => {
+            const label = this.labelSignal();
+            if (label) {
+                this._labelStringSignal.set(label.labelTextSignal());
+            }
+        });
 
-    ngAfterViewInit() {
-        this.labelString = this.label?.getLabel();
+        effect(() => {
+            this.labelSignal()?.setShouldShowAbove(!!this._shouldShowLabelAboveFieldSignal());
+        });
+
+        effect((onCleanup) => {
+            const badge = this.optionalBadgeSignal()?.nativeElement;
+            const label = this.labelSignal();
+            if (!badge || !label) {
+                label?.setBoundaryRight(null);
+                return;
+            }
+
+            const update = () => label.setBoundaryRight(badge.offsetLeft - labelBadgeGapPx);
+            update();
+
+            const observer = new ResizeObserver(update);
+            observer.observe(this._elementRef.nativeElement);
+            onCleanup(() => observer.disconnect());
+        });
     }
 
     onClear() {

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -108,6 +108,13 @@ export class PuibeFormFieldComponent {
     private readonly _labelStringSignal = signal('');
     protected readonly labelStringSignal = this._labelStringSignal.asReadonly();
 
+    /**
+     * @deprecated Use {@link labelStringSignal} instead. Kept for backwards compatibility.
+     */
+    public get labelString(): string {
+        return this._labelStringSignal();
+    }
+
     public id$ = this._formFieldService.id$;
     public isOptional$ = this._formFieldService.isRequired$.pipe(
         combineLatestWith(this._hideOptionalSubject),

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -8,7 +8,6 @@ import {
     ElementRef,
     inject,
     Input,
-    signal,
     viewChild,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -78,7 +77,7 @@ const overlayTextEmptyClassName = 'text-opacity-60';
 })
 export class PuibeFormFieldComponent {
     private readonly _formFieldService = inject(FormFieldService);
-    private readonly _readonlyDirective = inject(PuibeReadonlyDirective, { optional: true })
+    private readonly _readonlyDirective = inject(PuibeReadonlyDirective, { optional: true });
     private readonly _elementRef = inject(ElementRef<HTMLElement>);
 
     isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
@@ -109,14 +108,13 @@ export class PuibeFormFieldComponent {
 
     private readonly _optionalBadgeSignal = viewChild<ElementRef<HTMLElement>>('optionalBadge');
 
-    private readonly _labelStringSignal = signal('');
-    public readonly labelStringSignal = this._labelStringSignal.asReadonly();
+    public readonly labelStringSignal = computed(() => this._labelSignal()?.labelTextSignal() ?? '');
 
     /**
      * @deprecated Use {@link labelStringSignal} instead. Kept for backwards compatibility.
      */
     get labelString(): string {
-        return this._labelStringSignal();
+        return this.labelStringSignal();
     }
 
     id$ = this._formFieldService.id$;
@@ -233,13 +231,6 @@ export class PuibeFormFieldComponent {
     });
 
     constructor() {
-        effect(() => {
-            const label = this._labelSignal();
-            if (label) {
-                this._labelStringSignal.set(label.labelTextSignal());
-            }
-        });
-
         effect(() => {
             this._labelSignal()?.setShouldShowAboveField(!!this._shouldShowLabelAboveFieldSignal());
         });

--- a/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/form-field.component.ts
@@ -97,7 +97,7 @@ export class PuibeFormFieldComponent {
     @Input()
     public readonlyEmptyValuePlaceholder: string;
 
-    public readonly labelSignal = contentChild(PuibeLabelDirective);
+    protected readonly labelSignal = contentChild(PuibeLabelDirective);
 
     public get label(): PuibeLabelDirective | undefined {
         return this.labelSignal();
@@ -106,7 +106,7 @@ export class PuibeFormFieldComponent {
     private readonly _optionalBadgeSignal = viewChild<ElementRef<HTMLElement>>('optionalBadge');
 
     private readonly _labelStringSignal = signal('');
-    protected readonly labelStringSignal = this._labelStringSignal.asReadonly();
+    public readonly labelStringSignal = this._labelStringSignal.asReadonly();
 
     /**
      * @deprecated Use {@link labelStringSignal} instead. Kept for backwards compatibility.
@@ -188,7 +188,7 @@ export class PuibeFormFieldComponent {
             }
 
             return Object.entries(errors)
-                .map(([key, value]) => [this.capitalizeFirstLetter(key), value] as const)
+                .map(([key, value]) => [this._capitalizeFirstLetter(key), value] as const)
                 .map(([key, value]) => ({
                     key: `Messages.Validation_${key}`,
                     param: value,
@@ -317,7 +317,7 @@ export class PuibeFormFieldComponent {
         );
     }
 
-    private capitalizeFirstLetter(value: string) {
+    private _capitalizeFirstLetter(value: string) {
         return value.charAt(0).toUpperCase() + value.slice(1);
     }
 }

--- a/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
@@ -95,7 +95,7 @@ export class PuibeLabelDirective implements OnInit {
     /**
      * @deprecated Use {@link labelTextSignal} instead. Kept for backwards compatibility.
      */
-    public getLabel(): string {
+    getLabel(): string {
         return this._elementRef.nativeElement.innerText;
     }
 

--- a/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
@@ -20,7 +20,7 @@ const hiddenClassName = 'translate-y-7 opacity-0';
 })
 export class PuibeLabelDirective implements OnInit {
     private readonly _alwaysVisibleSignal = signal(false);
-    readonly alwaysVisibleSignal = this._alwaysVisibleSignal.asReadonly();
+    public readonly alwaysVisibleSignal = this._alwaysVisibleSignal.asReadonly();
 
     @Input()
     set alwaysVisible(value: boolean) {
@@ -28,10 +28,10 @@ export class PuibeLabelDirective implements OnInit {
     }
 
     private readonly _heightSignal = signal(0);
-    readonly heightSignal = this._heightSignal.asReadonly();
+    public readonly heightSignal = this._heightSignal.asReadonly();
 
     private readonly _labelTextSignal = signal('');
-    readonly labelTextSignal = this._labelTextSignal.asReadonly();
+    public readonly labelTextSignal = this._labelTextSignal.asReadonly();
 
     private readonly _boundaryRightSignal = signal<number | null>(null);
 

--- a/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
@@ -1,13 +1,13 @@
-import { Directive, ElementRef, HostBinding, Input, OnInit } from '@angular/core';
+import { Directive, effect, ElementRef, Input, OnInit, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { DestroyService } from '@nexplore/practices-ui';
-import { BehaviorSubject, combineLatest, Observable, takeUntil } from 'rxjs';
+import { Observable, shareReplay, takeUntil } from 'rxjs';
 import { combineLatestWith } from 'rxjs/operators';
 import { setHostAttr, setHostClassNames } from '../util/utils';
-import { PuibeFormFieldComponent } from './form-field.component';
 import { FormFieldService } from './form-field.service';
 
 const className =
-    'z-20 text-very-small absolute -top-5 left-6 bg-white rounded-lg px-1 py-0.5 transition-all duration-200 ease-out';
+    'z-20 text-very-small absolute bottom-full top-auto left-6 bg-white rounded-lg px-1 py-0.5 transition-all duration-200 ease-out';
 const invalidClassName = 'text-red';
 const visibleClassName = 'translate-y-2 opacity-100';
 const hiddenClassName = 'translate-y-7 opacity-0';
@@ -16,36 +16,50 @@ const hiddenClassName = 'translate-y-7 opacity-0';
     standalone: true,
     selector: 'label[puibeLabel]',
     providers: [DestroyService],
+    host: { class: className },
 })
 export class PuibeLabelDirective implements OnInit {
-    private _alwaysVisibleSubject = new BehaviorSubject<boolean>(false);
+    private readonly _alwaysVisibleSignal = signal(false);
+    readonly alwaysVisibleSignal = this._alwaysVisibleSignal.asReadonly();
 
     @Input()
     set alwaysVisible(value: boolean) {
-        this._alwaysVisibleSubject.next(value);
+        this._alwaysVisibleSignal.set(value);
     }
 
-    @HostBinding('class')
-    className = className;
+    private readonly _heightSignal = signal(0);
+    readonly heightSignal = this._heightSignal.asReadonly();
+
+    private readonly _labelTextSignal = signal('');
+    readonly labelTextSignal = this._labelTextSignal.asReadonly();
+
+    private readonly _boundaryRightSignal = signal<number | null>(null);
+
+    private readonly _shouldShowAboveSignal = signal(false);
+
+    private readonly _alwaysVisible$ = toObservable(this.alwaysVisibleSignal);
 
     constructor(
         private _elementRef: ElementRef<HTMLLabelElement>,
         private _formFieldService: FormFieldService,
-        private _formFieldComponent: PuibeFormFieldComponent,
         private _destroy$: DestroyService
-    ) {}
+    ) {
+        effect(() => {
+            const boundary = this._boundaryRightSignal();
+            const el = this._elementRef.nativeElement;
+            el.style.maxWidth = boundary == null ? '' : `${Math.max(0, boundary - el.offsetLeft)}px`;
+        });
+
+        effect(() => {
+            const hidden = !this._shouldShowAboveSignal() && !this.alwaysVisibleSignal();
+            setHostClassNames({ [hiddenClassName]: hidden, [visibleClassName]: !hidden }, this._elementRef);
+        });
+    }
 
     ngOnInit() {
         this._formFieldService.id$
             .pipe(takeUntil(this._destroy$))
             .subscribe((id) => setHostAttr('for', id, this._elementRef));
-
-        combineLatest([this._alwaysVisibleSubject, this._formFieldComponent.shouldShowLabelAboveField$])
-            .pipe(takeUntil(this._destroy$))
-            .subscribe(([alwaysVisible, shouldShowLabelAboveField]) => {
-                const hidden = !shouldShowLabelAboveField && !alwaysVisible;
-                setHostClassNames({ [hiddenClassName]: hidden, [visibleClassName]: !hidden }, this._elementRef);
-            });
 
         this._formFieldService.displayAsInvalid$
             .pipe(takeUntil(this._destroy$))
@@ -53,8 +67,12 @@ export class PuibeLabelDirective implements OnInit {
                 setHostClassNames({ [invalidClassName]: displayAsInvalid }, this._elementRef)
             );
 
-        this._getLabelText$()
-            .pipe(combineLatestWith(this._alwaysVisibleSubject), takeUntil(this._destroy$))
+        const labelText$ = this._getLabelText$().pipe(shareReplay({ refCount: true, bufferSize: 1 }));
+
+        labelText$.pipe(takeUntil(this._destroy$)).subscribe((labelText) => this._labelTextSignal.set(labelText));
+
+        labelText$
+            .pipe(combineLatestWith(this._alwaysVisible$), takeUntil(this._destroy$))
             .subscribe(([labelText, alwaysVisible]) => {
                 if (!alwaysVisible) {
                     this._formFieldService.setLabelAsPlaceholder(labelText);
@@ -62,10 +80,25 @@ export class PuibeLabelDirective implements OnInit {
                     this._formFieldService.setLabelAsPlaceholder(null);
                 }
             });
+
+        this._observeHeight();
     }
 
-    getLabel() {
-        return this._elementRef.nativeElement.innerText;
+    public setBoundaryRight(rightBoundaryPx: number | null): void {
+        this._boundaryRightSignal.set(rightBoundaryPx);
+    }
+
+    public setShouldShowAbove(value: boolean): void {
+        this._shouldShowAboveSignal.set(value);
+    }
+
+    private _observeHeight() {
+        const el = this._elementRef.nativeElement;
+        const observer = new ResizeObserver(() => this._heightSignal.set(el.offsetHeight));
+        observer.observe(el);
+        this._heightSignal.set(el.offsetHeight);
+
+        this._destroy$.subscribe(() => observer.disconnect());
     }
 
     private _getLabelText$() {

--- a/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, effect, ElementRef, Input, OnInit, signal } from '@angular/core';
+import { Directive, effect, ElementRef, inject, input, OnInit, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { DestroyService } from '@nexplore/practices-ui';
 import { Observable, shareReplay, takeUntil } from 'rxjs';
@@ -19,13 +19,11 @@ const hiddenClassName = 'translate-y-7 opacity-0';
     host: { class: className },
 })
 export class PuibeLabelDirective implements OnInit {
-    private readonly _alwaysVisibleSignal = signal(false);
-    public readonly alwaysVisibleSignal = this._alwaysVisibleSignal.asReadonly();
+    private readonly _elementRef = inject(ElementRef<HTMLLabelElement>);
+    private readonly _formFieldService = inject(FormFieldService);
+    private readonly _destroy$ = inject(DestroyService);
 
-    @Input()
-    set alwaysVisible(value: boolean) {
-        this._alwaysVisibleSignal.set(value);
-    }
+    public readonly alwaysVisibleSignal = input(false, { alias: 'alwaysVisible' });
 
     private readonly _heightSignal = signal(0);
     public readonly heightSignal = this._heightSignal.asReadonly();
@@ -33,25 +31,21 @@ export class PuibeLabelDirective implements OnInit {
     private readonly _labelTextSignal = signal('');
     public readonly labelTextSignal = this._labelTextSignal.asReadonly();
 
-    private readonly _boundaryRightSignal = signal<number | null>(null);
+    private readonly _rightBoundarySignal = signal<number | null>(null);
 
-    private readonly _shouldShowAboveSignal = signal(false);
+    private readonly _shouldShowAboveFieldSignal = signal(false);
 
     private readonly _alwaysVisible$ = toObservable(this.alwaysVisibleSignal);
 
-    constructor(
-        private _elementRef: ElementRef<HTMLLabelElement>,
-        private _formFieldService: FormFieldService,
-        private _destroy$: DestroyService
-    ) {
+    constructor() {
         effect(() => {
-            const boundary = this._boundaryRightSignal();
+            const boundary = this._rightBoundarySignal();
             const el = this._elementRef.nativeElement;
             el.style.maxWidth = boundary == null ? '' : `${Math.max(0, boundary - el.offsetLeft)}px`;
         });
 
         effect(() => {
-            const hidden = !this._shouldShowAboveSignal() && !this.alwaysVisibleSignal();
+            const hidden = !this._shouldShowAboveFieldSignal() && !this.alwaysVisibleSignal();
             setHostClassNames({ [hiddenClassName]: hidden, [visibleClassName]: !hidden }, this._elementRef);
         });
     }
@@ -84,12 +78,12 @@ export class PuibeLabelDirective implements OnInit {
         this._observeHeight();
     }
 
-    public setBoundaryRight(rightBoundaryPx: number | null): void {
-        this._boundaryRightSignal.set(rightBoundaryPx);
+    public setRightBoundary(rightBoundaryPx: number | null): void {
+        this._rightBoundarySignal.set(rightBoundaryPx);
     }
 
-    public setShouldShowAbove(value: boolean): void {
-        this._shouldShowAboveSignal.set(value);
+    public setShouldShowAboveField(value: boolean): void {
+        this._shouldShowAboveFieldSignal.set(value);
     }
 
     /**
@@ -101,9 +95,12 @@ export class PuibeLabelDirective implements OnInit {
 
     private _observeHeight() {
         const el = this._elementRef.nativeElement;
-        const observer = new ResizeObserver(() => this._heightSignal.set(el.offsetHeight));
+
+        const update = () => this._heightSignal.set(el.offsetHeight);;
+        update();
+
+        const observer = new ResizeObserver(update);
         observer.observe(el);
-        this._heightSignal.set(el.offsetHeight);
 
         this._destroy$.subscribe(() => observer.disconnect());
     }

--- a/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
+++ b/ng/practices-ui-ktbe/src/lib/form-field/label.directive.ts
@@ -92,6 +92,13 @@ export class PuibeLabelDirective implements OnInit {
         this._shouldShowAboveSignal.set(value);
     }
 
+    /**
+     * @deprecated Use {@link labelTextSignal} instead. Kept for backwards compatibility.
+     */
+    public getLabel(): string {
+        return this._elementRef.nativeElement.innerText;
+    }
+
     private _observeHeight() {
         const el = this._elementRef.nativeElement;
         const observer = new ResizeObserver(() => this._heightSignal.set(el.offsetHeight));

--- a/ng/practices-ui-ktbe/src/lib/input/input.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/input/input.stories.ts
@@ -338,3 +338,98 @@ export const ReadonlyTextareaWithCustomEmptyPlaceholder: Story = {
         readonlyEmptyValuePlaceholder: 'Custom Value',
     },
 };
+
+const LONG_LABEL = 'Hier können Sie das selbstverletzende Verhalten qualitativ beschreiben (inkl. Auslösefaktoren)';
+const VERY_LONG_LABEL =
+    'Weitere selbstverletzende Verhaltensweisen, die in J1 nicht aufgeführt sind, sowie ergänzende Beobachtungen und Hinweise für die weitere Begleitung und Betreuung im Alltag';
+
+export const LongLabelTextInput: Story = {
+    name: 'Long label – text input (filled)',
+    args: {
+        value: 'Ein bereits eingegebener Wert',
+        label: LONG_LABEL,
+        inputType: 'text',
+    },
+};
+
+export const LongLabelTextInputEmpty: Story = {
+    name: 'Long label – text input (empty / placeholder)',
+    args: {
+        label: LONG_LABEL,
+        inputType: 'text',
+    },
+};
+
+export const LongLabelAlwaysVisible: Story = {
+    name: 'Long label – always visible',
+    args: {
+        label: VERY_LONG_LABEL,
+        inputType: 'text',
+        labelAlwaysVisible: true,
+    },
+};
+
+export const LongLabelTextarea: Story = {
+    name: 'Long label – textarea (filled)',
+    args: {
+        value: 'sdfsdf',
+        label: VERY_LONG_LABEL,
+        inputType: 'textarea',
+    },
+};
+
+export const LongLabelWithError: Story = {
+    name: 'Long label – required with error',
+    render: () => {
+        const control = new FormControl('', Validators.required);
+        control.markAsTouched();
+        return {
+            props: { formGroup: new FormGroup({ value: control }) },
+            template: `
+                <puibe-form-field class="w-1/2" [formGroup]="formGroup">
+                    <label puibeLabel>${LONG_LABEL}</label>
+                    <input puibeInput type="text" formControlName="value" />
+                </puibe-form-field>`,
+        };
+    },
+};
+
+export const LongLabelWithErrorAlwaysVisible: Story = {
+    name: 'Long label – required with error (always visible)',
+    render: () => {
+        const control = new FormControl('', Validators.required);
+        control.markAsTouched();
+        return {
+            props: { formGroup: new FormGroup({ value: control }) },
+            template: `
+                <puibe-form-field class="w-1/2" [formGroup]="formGroup">
+                    <label puibeLabel [alwaysVisible]="true">${LONG_LABEL}</label>
+                    <input puibeInput type="text" formControlName="value" />
+                </puibe-form-field>`,
+        };
+    },
+};
+
+export const LongLabelsStacked: Story = {
+    name: 'Long labels – stacked (no overlap between fields)',
+    render: () => ({
+        props: {
+            formGroup: new FormGroup({
+                first: new FormControl('Erster Wert'),
+                second: new FormControl('Zweiter Wert'),
+            }),
+        },
+        template: `
+            <div class="flex w-1/2 flex-col gap-4" [formGroup]="formGroup">
+                <p>Two stacked fields with long labels, the lower label grows upwards and does not overlap the field above it.</p>
+                <puibe-form-field>
+                    <label puibeLabel>${VERY_LONG_LABEL}</label>
+                    <textarea puibeInput formControlName="first"></textarea>
+                </puibe-form-field>
+                <puibe-form-field>
+                    <label puibeLabel>${LONG_LABEL}</label>
+                    <input puibeInput type="text" formControlName="second" />
+                </puibe-form-field>
+            </div>`,
+    }),
+};

--- a/ng/practices-ui-ktbe/src/lib/input/input.stories.ts
+++ b/ng/practices-ui-ktbe/src/lib/input/input.stories.ts
@@ -339,12 +339,12 @@ export const ReadonlyTextareaWithCustomEmptyPlaceholder: Story = {
     },
 };
 
-const LONG_LABEL = 'Hier können Sie das selbstverletzende Verhalten qualitativ beschreiben (inkl. Auslösefaktoren)';
+const LONG_LABEL = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut';
 const VERY_LONG_LABEL =
-    'Weitere selbstverletzende Verhaltensweisen, die in J1 nicht aufgeführt sind, sowie ergänzende Beobachtungen und Hinweise für die weitere Begleitung und Betreuung im Alltag';
+    'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et';
 
 export const LongLabelTextInput: Story = {
-    name: 'Long label – text input (filled)',
+    name: 'Long label - text input (filled)',
     args: {
         value: 'Ein bereits eingegebener Wert',
         label: LONG_LABEL,
@@ -353,7 +353,7 @@ export const LongLabelTextInput: Story = {
 };
 
 export const LongLabelTextInputEmpty: Story = {
-    name: 'Long label – text input (empty / placeholder)',
+    name: 'Long label - text input (empty / placeholder)',
     args: {
         label: LONG_LABEL,
         inputType: 'text',
@@ -361,7 +361,7 @@ export const LongLabelTextInputEmpty: Story = {
 };
 
 export const LongLabelAlwaysVisible: Story = {
-    name: 'Long label – always visible',
+    name: 'Long label - always visible',
     args: {
         label: VERY_LONG_LABEL,
         inputType: 'text',
@@ -370,16 +370,16 @@ export const LongLabelAlwaysVisible: Story = {
 };
 
 export const LongLabelTextarea: Story = {
-    name: 'Long label – textarea (filled)',
+    name: 'Long label - textarea (filled)',
     args: {
-        value: 'sdfsdf',
+        value: 'Bereits eingegeben',
         label: VERY_LONG_LABEL,
         inputType: 'textarea',
     },
 };
 
 export const LongLabelWithError: Story = {
-    name: 'Long label – required with error',
+    name: 'Long label - required with error',
     render: () => {
         const control = new FormControl('', Validators.required);
         control.markAsTouched();
@@ -395,7 +395,7 @@ export const LongLabelWithError: Story = {
 };
 
 export const LongLabelWithErrorAlwaysVisible: Story = {
-    name: 'Long label – required with error (always visible)',
+    name: 'Long label - required with error (always visible)',
     render: () => {
         const control = new FormControl('', Validators.required);
         control.markAsTouched();
@@ -411,7 +411,7 @@ export const LongLabelWithErrorAlwaysVisible: Story = {
 };
 
 export const LongLabelsStacked: Story = {
-    name: 'Long labels – stacked (no overlap between fields)',
+    name: 'Long labels - stacked (no overlap between fields)',
     render: () => ({
         props: {
             formGroup: new FormGroup({


### PR DESCRIPTION
## Description

Long PuibeLabelDirective labels wrapped downward and covered the input. The floating label is now bottom-anchored (grows upward) and PuibeFormFieldComponent reserves matching top space, preserving the notch look and float animation. Long labels are also capped at the optional badge boundary so they no longer cover it.

Internals were refactored to signals and the circular directive<->component injection was removed. Public API (PuibeFormFieldComponent.label getter, PuibeLabelDirective.alwaysVisible setter) is unchanged.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built the library and consumed it in a downstream frontend; verified the notch look and float animation are preserved and that long labels no longer overlap the input or the optional badge on desktop. Added Storybook edge-case stories in `input.stories.ts`.

## Integration Instructions

N/A — public API unchanged. Consumers receive the fix by upgrading the package.
