### PR TITLE
Fix Tailwind form-field long-label layout

### DIFF
--- a/ng/practices-ui-tailwind/src/lib/form-field/form-field.component.html
+++ b/ng/practices-ui-tailwind/src/lib/form-field/form-field.component.html
@@ -1,5 +1,5 @@
 @if ((isReadonly$ | async) === false) {
-    <div class="relative mt-5">
+    <div class="relative">
         <ng-content select="label[puiLabel]"></ng-content>
         @if (overlayTextValue$ | async; as overlayTextValue) {
             <div [ngClass]="overlayTextClassName$ | async" aria-hidden="true">
@@ -72,6 +72,7 @@
         ) {
             @if (context.isOptional) {
                 <span
+                    #optionalBadge
                     class="text-very-small absolute -top-5 z-10 translate-y-2 rounded-lg bg-white px-1 py-0.5"
                     [ngClass]="{ 'right-[75px]': context.isCustomIconFilled, 'right-3': !context.isCustomIconFilled }"
                     [class.text-red]="context.displayAsInvalid"
@@ -103,7 +104,7 @@
         <ng-content></ng-content>
     </div>
 } @else {
-    <pui-readonly-label-value [label]="labelString" [useSmallLabel]="useSmallTextForReadonlyLabel">
+    <pui-readonly-label-value [label]="labelStringSignal()" [useSmallLabel]="useSmallTextForReadonlyLabel">
         @if (ngControlValueSignal(); as value) {
             @if (hasValueSignal()) {
                 <ng-content select="[slot='readonly-prefix']" />

--- a/ng/practices-ui-tailwind/src/lib/form-field/form-field.component.ts
+++ b/ng/practices-ui-tailwind/src/lib/form-field/form-field.component.ts
@@ -1,13 +1,14 @@
 import { AsyncPipe, NgClass, NgComponentOutlet } from '@angular/common';
 import {
-    AfterViewInit,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    HostBinding,
-    Input,
     computed,
+    contentChild,
+    effect,
+    ElementRef,
     inject,
+    Input,
+    viewChild,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { PuiFormFieldDirective, PuiReadonlyDirective } from '@nexplore/practices-ng-forms';
@@ -33,6 +34,8 @@ import { FormFieldIconConfig, FormFieldService } from './form-field.service';
 import { PuiLabelDirective } from './label.directive';
 
 const className = 'block';
+const fieldTopSpacingPx = 20;
+const labelBadgeGapPx = 8;
 
 const iconContainerDefaultClassName =
     'absolute right-[2px] top-[2px] z-10 flex h-[calc(var(--spacing-pui-controlsize)-4px))] items-center';
@@ -66,13 +69,17 @@ const overlayTextEmptyClassName = 'text-opacity-60';
     selector: 'pui-form-field',
     standalone: true,
     templateUrl: './form-field.component.html',
+    host: {
+        class: className,
+        '[style.padding-top]': 'hostPaddingTopSignal()',
+    },
 })
-export class PuiFormFieldComponent implements AfterViewInit {
-    private _formFieldService = inject(FormFieldService);
+export class PuiFormFieldComponent {
+    private readonly _formFieldService = inject(FormFieldService);
     private readonly _readonlyDirective = inject(PuiReadonlyDirective, { optional: true });
+    private readonly _elementRef = inject(ElementRef<HTMLElement>);
 
     isReadonly$ = this._readonlyDirective?.isReadonly$ ?? of(false);
-    labelString: string;
     protected readonly ngControlValueSignal = toSignal(this._formFieldService.readonlyValue$);
     protected readonly hasValueSignal = computed(() => {
         const value = this.ngControlValueSignal();
@@ -98,12 +105,24 @@ export class PuiFormFieldComponent implements AfterViewInit {
     }
 
     @Input()
-    readonlyEmptyValuePlaceholder: string;
+    readonlyEmptyValuePlaceholder: string | null = null;
 
-    @ContentChild(PuiLabelDirective) label: PuiLabelDirective;
+    private readonly _labelSignal = contentChild(PuiLabelDirective);
 
-    @HostBinding('class')
-    className = className;
+    get label(): PuiLabelDirective | undefined {
+        return this._labelSignal();
+    }
+
+    private readonly _optionalBadgeSignal = viewChild<ElementRef<HTMLElement>>('optionalBadge');
+
+    public readonly labelStringSignal = computed(() => this._labelSignal()?.labelTextSignal() ?? '');
+
+    /**
+     * @deprecated Use {@link labelStringSignal} instead. Kept for backwards compatibility.
+     */
+    get labelString(): string {
+        return this.labelStringSignal();
+    }
 
     id$ = this._formFieldService.id$;
     isOptional$ = this._formFieldService.isRequired$.pipe(
@@ -176,7 +195,7 @@ export class PuiFormFieldComponent implements AfterViewInit {
             }
 
             return Object.entries(errors)
-                .map(([key, value]) => [this.capitalizeFirstLetter(key), value] as const)
+                .map(([key, value]) => [this._capitalizeFirstLetter(key), value] as const)
                 .map(([key, value]) => ({
                     key: `Messages.Validation_${key}`,
                     param: value,
@@ -203,8 +222,39 @@ export class PuiFormFieldComponent implements AfterViewInit {
         shareReplay({ refCount: true, bufferSize: 1 }),
     );
 
-    ngAfterViewInit() {
-        this.labelString = this.label?.getLabel();
+    private readonly _shouldShowLabelAboveFieldSignal = toSignal(this.shouldShowLabelAboveField$, {
+        initialValue: false,
+    });
+    protected readonly hostPaddingTopSignal = computed(() => {
+        const label = this._labelSignal();
+        if (!label) {
+            return `${fieldTopSpacingPx}px`;
+        }
+
+        const reservedTopSpacingPx = Math.max(fieldTopSpacingPx, label.heightSignal());
+        return `${reservedTopSpacingPx}px`;
+    });
+
+    constructor() {
+        effect(() => {
+            this._labelSignal()?.setShouldShowAboveField(!!this._shouldShowLabelAboveFieldSignal());
+        });
+
+        effect((onCleanup) => {
+            const badge = this._optionalBadgeSignal()?.nativeElement;
+            const label = this._labelSignal();
+            if (!badge || !label) {
+                label?.setRightBoundary(null);
+                return;
+            }
+
+            const update = () => label.setRightBoundary(badge.offsetLeft - labelBadgeGapPx);
+            update();
+
+            const observer = new ResizeObserver(update);
+            observer.observe(this._elementRef.nativeElement);
+            onCleanup(() => observer.disconnect());
+        });
     }
 
     onClear() {
@@ -264,7 +314,7 @@ export class PuiFormFieldComponent implements AfterViewInit {
         );
     }
 
-    private capitalizeFirstLetter(value: string) {
+    private _capitalizeFirstLetter(value: string) {
         return value.charAt(0).toUpperCase() + value.slice(1);
     }
 }

--- a/ng/practices-ui-tailwind/src/lib/form-field/label.directive.ts
+++ b/ng/practices-ui-tailwind/src/lib/form-field/label.directive.ts
@@ -1,13 +1,13 @@
-import { Directive, ElementRef, HostBinding, Input, OnInit, inject } from '@angular/core';
+import { Directive, effect, ElementRef, inject, input, OnInit, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { DestroyService } from '@nexplore/practices-ui';
-import { BehaviorSubject, combineLatest, Observable, takeUntil } from 'rxjs';
+import { Observable, shareReplay, takeUntil } from 'rxjs';
 import { combineLatestWith } from 'rxjs/operators';
 import { setHostAttr, setHostClassNames } from '../util/utils';
-import { PuiFormFieldComponent } from './form-field.component';
 import { FormFieldService } from './form-field.service';
 
 const className =
-    'z-20 text-very-small absolute -top-5 left-6 bg-white rounded-lg px-1 py-0.5 transition-all duration-200 ease-out';
+    'z-20 text-very-small absolute bottom-full top-auto left-6 bg-white rounded-lg px-1 py-0.5 transition-all duration-200 ease-out';
 const invalidClassName = 'text-red';
 const visibleClassName = 'translate-y-2 opacity-100';
 const hiddenClassName = 'translate-y-7 opacity-0';
@@ -16,34 +16,44 @@ const hiddenClassName = 'translate-y-7 opacity-0';
     standalone: true,
     selector: 'label[puiLabel]',
     providers: [DestroyService],
+    host: { class: className },
 })
 export class PuiLabelDirective implements OnInit {
-    private _elementRef = inject<ElementRef<HTMLLabelElement>>(ElementRef);
-    private _formFieldService = inject(FormFieldService);
-    private _formFieldComponent = inject(PuiFormFieldComponent);
-    private _destroy$ = inject(DestroyService);
+    private readonly _elementRef = inject<ElementRef<HTMLLabelElement>>(ElementRef);
+    private readonly _formFieldService = inject(FormFieldService);
+    private readonly _destroy$ = inject(DestroyService);
 
-    private _alwaysVisibleSubject = new BehaviorSubject<boolean>(false);
+    public readonly alwaysVisibleSignal = input(false, { alias: 'alwaysVisible' });
 
-    @Input()
-    set alwaysVisible(value: boolean) {
-        this._alwaysVisibleSubject.next(value);
+    private readonly _heightSignal = signal(0);
+    public readonly heightSignal = this._heightSignal.asReadonly();
+
+    private readonly _labelTextSignal = signal('');
+    public readonly labelTextSignal = this._labelTextSignal.asReadonly();
+
+    private readonly _rightBoundarySignal = signal<number | null>(null);
+
+    private readonly _shouldShowAboveFieldSignal = signal(false);
+
+    private readonly _alwaysVisible$ = toObservable(this.alwaysVisibleSignal);
+
+    constructor() {
+        effect(() => {
+            const boundary = this._rightBoundarySignal();
+            const el = this._elementRef.nativeElement;
+            el.style.maxWidth = boundary == null ? '' : `${Math.max(0, boundary - el.offsetLeft)}px`;
+        });
+
+        effect(() => {
+            const hidden = !this._shouldShowAboveFieldSignal() && !this.alwaysVisibleSignal();
+            setHostClassNames({ [hiddenClassName]: hidden, [visibleClassName]: !hidden }, this._elementRef);
+        });
     }
-
-    @HostBinding('class')
-    className = className;
 
     ngOnInit() {
         this._formFieldService.id$
             .pipe(takeUntil(this._destroy$))
             .subscribe((id) => setHostAttr('for', id, this._elementRef));
-
-        combineLatest([this._alwaysVisibleSubject, this._formFieldComponent.shouldShowLabelAboveField$])
-            .pipe(takeUntil(this._destroy$))
-            .subscribe(([alwaysVisible, shouldShowLabelAboveField]) => {
-                const hidden = !shouldShowLabelAboveField && !alwaysVisible;
-                setHostClassNames({ [hiddenClassName]: hidden, [visibleClassName]: !hidden }, this._elementRef);
-            });
 
         this._formFieldService.displayAsInvalid$
             .pipe(takeUntil(this._destroy$))
@@ -51,8 +61,12 @@ export class PuiLabelDirective implements OnInit {
                 setHostClassNames({ [invalidClassName]: displayAsInvalid }, this._elementRef),
             );
 
-        this._getLabelText$()
-            .pipe(combineLatestWith(this._alwaysVisibleSubject), takeUntil(this._destroy$))
+        const labelText$ = this._getLabelText$().pipe(shareReplay({ refCount: true, bufferSize: 1 }));
+
+        labelText$.pipe(takeUntil(this._destroy$)).subscribe((labelText) => this._labelTextSignal.set(labelText));
+
+        labelText$
+            .pipe(combineLatestWith(this._alwaysVisible$), takeUntil(this._destroy$))
             .subscribe(([labelText, alwaysVisible]) => {
                 if (!alwaysVisible) {
                     this._formFieldService.setLabelAsPlaceholder(labelText);
@@ -60,10 +74,35 @@ export class PuiLabelDirective implements OnInit {
                     this._formFieldService.setLabelAsPlaceholder(null);
                 }
             });
+
+        this._observeHeight();
     }
 
-    getLabel() {
+    public setRightBoundary(rightBoundaryPx: number | null): void {
+        this._rightBoundarySignal.set(rightBoundaryPx);
+    }
+
+    public setShouldShowAboveField(value: boolean): void {
+        this._shouldShowAboveFieldSignal.set(value);
+    }
+
+    /**
+     * @deprecated Use {@link labelTextSignal} instead. Kept for backwards compatibility.
+     */
+    getLabel(): string {
         return this._elementRef.nativeElement.innerText;
+    }
+
+    private _observeHeight() {
+        const el = this._elementRef.nativeElement;
+
+        const update = () => this._heightSignal.set(el.offsetHeight);
+        update();
+
+        const observer = new ResizeObserver(update);
+        observer.observe(el);
+
+        this._destroy$.subscribe(() => observer.disconnect());
     }
 
     private _getLabelText$() {

--- a/ng/practices-ui-tailwind/src/lib/input/input.stories.ts
+++ b/ng/practices-ui-tailwind/src/lib/input/input.stories.ts
@@ -339,3 +339,98 @@ export const ReadonlyTextareaWithCustomEmptyPlaceholder: Story = {
     },
 };
 
+const LONG_LABEL = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut';
+const VERY_LONG_LABEL =
+    'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et';
+
+export const LongLabelTextInput: Story = {
+    name: 'Long label - text input (filled)',
+    args: {
+        value: 'Ein bereits eingegebener Wert',
+        label: LONG_LABEL,
+        inputType: 'text',
+    },
+};
+
+export const LongLabelTextInputEmpty: Story = {
+    name: 'Long label - text input (empty / placeholder)',
+    args: {
+        label: LONG_LABEL,
+        inputType: 'text',
+    },
+};
+
+export const LongLabelAlwaysVisible: Story = {
+    name: 'Long label - always visible',
+    args: {
+        label: VERY_LONG_LABEL,
+        inputType: 'text',
+        labelAlwaysVisible: true,
+    },
+};
+
+export const LongLabelTextarea: Story = {
+    name: 'Long label - textarea (filled)',
+    args: {
+        value: 'Bereits eingegeben',
+        label: VERY_LONG_LABEL,
+        inputType: 'textarea',
+    },
+};
+
+export const LongLabelWithError: Story = {
+    name: 'Long label - required with error',
+    render: () => {
+        const control = new FormControl('', Validators.required);
+        control.markAsTouched();
+        return {
+            props: { formGroup: new FormGroup({ value: control }) },
+            template: `
+                <pui-form-field class="w-1/2" [formGroup]="formGroup">
+                    <label puiLabel>${LONG_LABEL}</label>
+                    <input puiInput type="text" formControlName="value" />
+                </pui-form-field>`,
+        };
+    },
+};
+
+export const LongLabelWithErrorAlwaysVisible: Story = {
+    name: 'Long label - required with error (always visible)',
+    render: () => {
+        const control = new FormControl('', Validators.required);
+        control.markAsTouched();
+        return {
+            props: { formGroup: new FormGroup({ value: control }) },
+            template: `
+                <pui-form-field class="w-1/2" [formGroup]="formGroup">
+                    <label puiLabel [alwaysVisible]="true">${LONG_LABEL}</label>
+                    <input puiInput type="text" formControlName="value" />
+                </pui-form-field>`,
+        };
+    },
+};
+
+export const LongLabelsStacked: Story = {
+    name: 'Long labels - stacked (no overlap between fields)',
+    render: () => ({
+        props: {
+            formGroup: new FormGroup({
+                first: new FormControl('Erster Wert'),
+                second: new FormControl('Zweiter Wert'),
+            }),
+        },
+        template: `
+            <div class="flex w-1/2 flex-col gap-4" [formGroup]="formGroup">
+                <p>Two stacked fields with long labels, the lower label grows upwards and does not overlap the field above it.</p>
+                <pui-form-field>
+                    <label puiLabel>${VERY_LONG_LABEL}</label>
+                    <textarea puiInput formControlName="first"></textarea>
+                </pui-form-field>
+                <pui-form-field>
+                    <label puiLabel>${LONG_LABEL}</label>
+                    <input puiInput type="text" formControlName="second" />
+                </pui-form-field>
+            </div>`,
+    }),
+};
+


### PR DESCRIPTION
🤖

## Summary

- Port the current-main long-label form-field layout fix into the generic Tailwind library.
- Reserve dynamic top space for multi-line labels and constrain labels before the optional badge.
- Add focused long-label Storybook coverage for filled, empty, always-visible, error, textarea, and stacked cases.
- Preserve the existing public label accessors and [alwaysVisible] input while removing the circular form-field/label injection.

## Verification

Automated checks and repository review are reflected in the current pull-request state. Detailed execution records are kept privately.