### PR TITLE
Fail on missing documentation input paths

### DIFF
--- a/.codex/skills/documentation-codebase-sync/scripts/check-local-markdown-links.js
+++ b/.codex/skills/documentation-codebase-sync/scripts/check-local-markdown-links.js
@@ -212,6 +212,16 @@ function main() {
   const files = [];
   const targets = inputs.length ? inputs : ["."];
 
+  if (inputs.length) {
+    const missingInputs = inputs.filter((input) => !fs.existsSync(path.resolve(root, input)));
+    if (missingInputs.length) {
+      for (const input of missingInputs) {
+        console.error(`Input path does not exist: ${input}`);
+      }
+      process.exit(2);
+    }
+  }
+
   for (const input of targets) {
     walkMarkdown(path.resolve(root, input), files);
   }

--- a/.codex/skills/documentation-codebase-sync/scripts/check-local-markdown-links.test.js
+++ b/.codex/skills/documentation-codebase-sync/scripts/check-local-markdown-links.test.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const script = path.join(__dirname, "check-local-markdown-links.js");
+
+function run(root, ...inputs) {
+  return spawnSync(process.execPath, [script, "--root", root, ...inputs], {
+    encoding: "utf8",
+  });
+}
+
+test("fails clearly when an explicit input path is missing", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "markdown-links-"));
+
+  try {
+    const result = run(root, "missing-docs");
+
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /Input path does not exist: missing-docs/);
+    assert.equal(result.stdout, "");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("checks existing Markdown file and directory inputs successfully", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "markdown-links-"));
+
+  try {
+    fs.mkdirSync(path.join(root, "docs"));
+    fs.writeFileSync(path.join(root, "README.md"), "# Home\n\n[Guide](docs/guide.md)\n");
+    fs.writeFileSync(path.join(root, "docs", "guide.md"), "# Guide\n\n[Home](../README.md)\n");
+
+    const result = run(root, "README.md", "docs");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, "");
+    assert.match(result.stdout, /Checked 2 Markdown file\(s\), no local Markdown link problems found\./);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the CLI helper introduced by #48 so explicitly supplied missing file or directory paths fail with a clear diagnostic and exit status 2 instead of being silently ignored.

- Original PR: https://github.com/nexplore/nexplore-practices/pull/48
- Original PR head verified unchanged before publication: `da831284331f5d1351484e1f34d470d5da3c78c0`
- Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a6c7e2a14f48325b03fc6f1ebbe07c4
- Cloud-produced diff applied unchanged; publication commit: `97db4c8`

## Verification

- `git diff --cached --check`: passed
- `node --check .codex/skills/documentation-codebase-sync/scripts/check-local-markdown-links.js`: passed
- `node --test .codex/skills/documentation-codebase-sync/scripts/check-local-markdown-links.test.js`: 2 passed
- Markdown link checker against the skill, README, and CONTRIBUTING docs: passed

Automation assistance was used for this bounded repair. Draft remains draft for maintainer review.