### PR TITLE
docs: update translation rewrite API in Practices.Ui/Translations.md

### DIFF
--- a/docs/Practices.Ui/Translations.md
+++ b/docs/Practices.Ui/Translations.md
@@ -14,38 +14,58 @@ Practices.UI utilizes these prefixes for the keys:
 
 ## Configuration
 
-If you want to rewrite the prefixes, you can do so by providing a rewrite configuration to `providePractices()`.
-Such a config requires a key, which represents the prefix you want to rewrite and an object with a `rewriteTo` property
-and an optional `fallbackTo` property:
+If you want to rewrite the prefixes, you can do so by passing `rewriteResourceConfig` to `providePractices()`.
+Its `rewriteTypeConfig` maps each prefix you want to rewrite to an object with a `rewriteTo` property and an optional
+`fallbackTo` property:
 
 ```ts
 ...
 bootstrapApplication(AppComponent, {
     providers: [
         providePractices({
-            rewriteResourceTypes: {
-                "Practices": {
-                    rewriteTo: "MyApp",
-                    fallbackTo: "MyGeneral"
+            rewriteResourceConfig: {
+                rewriteTypeConfig: {
+                    Practices: {
+                        rewriteTo: 'MyApp',
+                        fallbackTo: 'MyGeneral',
+                    },
+                    Messages: {
+                        rewriteTo: 'MyMessages',
+                    },
                 },
-                "Messages": {
-                    rewriteTo: "MyMessages",
-                }
-            }
-        })
-    ]
+            },
+        }),
+    ],
 });
 ```
 
-This will inject a custom `TranslateParser` (`RewriteTranslateParser`) which will rewrite keys if it encouters a key with a prefix which is configured in `rewriteResourceTypes`.
+This configures `RewriteMissingTranslationHandler` as ngx-translate's `MissingTranslationHandler`. When ngx-translate
+cannot resolve a key, the handler checks its prefix against `rewriteTypeConfig` and tries the corresponding rewritten key.
 
 Some examples for the configuration above:
 
 - `Practices.Labels_Title` -> `MyApp.Labels_Title` -> `MyGeneral.Labels_Title`
 - `Messages.Labels_Title` -> `MyMessages.Labels_Title`
 
-If it fails to resolve the rewritten key for `rewriteTo`, it will try to resolve the key for `fallbackTo`.
-If that fails as well, it will return `undefined`, which is the default behaviour of ngx-translate's [`TranslateDefaultParser`](https://github.com/ngx-translate/core/blob/master/packages/core/lib/translate.parser.ts).
+If the handler cannot resolve the key configured by `rewriteTo`, it tries the key configured by `fallbackTo`, when
+present. If neither key resolves (or the original key has no configured prefix), it returns the original missing key.
+You can optionally set `missingKeyTransformFn` alongside `rewriteTypeConfig` to transform that returned key:
+
+```ts
+providePractices({
+    rewriteResourceConfig: {
+        rewriteTypeConfig: {
+            Practices: {
+                rewriteTo: 'MyApp',
+                fallbackTo: 'MyGeneral',
+            },
+        },
+        missingKeyTransformFn: (key) => `[${key}]`,
+    },
+});
+```
+
+With this function, an unresolved `Practices.Labels_Title` is returned as `[Practices.Labels_Title]`.
 
 ## TitleService
 


### PR DESCRIPTION
### Motivation

- The repository README was updated to the current API but `docs/Practices.Ui/Translations.md` still described the removed `RewriteTranslateParser` and the old `rewriteResourceTypes` option, so the document needed to be aligned with the current implementation which uses `RewriteMissingTranslationHandler` and `rewriteResourceConfig.rewriteTypeConfig` (breaking migration recorded in the changelog).

### Description

- Replace the old `rewriteResourceTypes` example with `rewriteResourceConfig: { rewriteTypeConfig: ... }` and adjust example syntax to match the current `providePractices()` API. 
- Replace the stale `RewriteTranslateParser` description with the actual `RewriteMissingTranslationHandler` behavior and explain how it rewrites keys and falls back to `fallbackTo`.
- Document the optional `missingKeyTransformFn` configuration and show an example that matches the handler implementation and fallback/missing-key behavior.
- Preserve the existing `TitleService` text and other unrelated content.

### Testing

- Changed file: `docs/Practices.Ui/Translations.md`.
- Ran `git diff --check` with no output indicating no whitespace issues (`git diff --check` produced no output).
- Verified local links with the included Python check script which printed: `All local links in docs/Practices.Ui/Translations.md resolve.` (command run: the inline Python script in the transcript).
- Confirmed only the docs file changed with `git diff --name-only` which returned `docs/Practices.Ui/Translations.md` and committed the change with `git commit -m "docs: update translation rewrite API"` producing `f75f64c docs: update translation rewrite API` as the most recent commit on branch `review/pr-49-b16b428-stale-translation-docs`.
