### PR TITLE
Revert Changelog to 11.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # NOTE: CHANGELOG.md is deprecated
 
-After the release of v11.3.0, please see the [GitHub release notes](https://github.com/nexplore/nexplore-practices/releases) for the practices in order to view the most up-to-date changes.
+> [!IMPORTANT]
+> After the release of v11.3.0, please see the [GitHub release notes](https://github.com/nexplore/nexplore-practices/releases) for the practices in order to view the most up-to-date changes.
 
 # Changelog
 
@@ -8,23 +9,6 @@ All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Added
-
-- `Practices.Core` Added NowOffset and UtcNowOffset to `IClock`
-- `Practices.Core` Added TimeProviderClock
-
-### Changed
-
-- `Nexplore.Practices.EntityFramework` Introduced `IAsyncValidatable` for async validations
-- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of SaveChanges for `IUnitOfWork`
-- _BREAKING_ `Nexplore.Practices.EntityFramework` Calling SaveChanges throws NotSupportedException
-- _BREAKING_ `Nexplore.Practices.EntityFramework` Removed sync version of CommitDbTransaction for `IUnitOfWorkWithSingleDbTransaction`
-- _BREAKING_ `Practices.Core` Changed Today and UtcToday on `IClock` from DateTime to DateOnly
-- `practices-ui-ktbe` Added support for displaying custom left heading inside `PuibeExpansionPanelComponent` via a `heading-before` slot
-- `practices-ui-ktbe` Added `truncateHeading` input to `PuibeExpansionPanelComponent` to truncate long headings with ellipsis.
 
 ## [11.3.0](https://github.com/nexplore/nexplore-practices/releases/tag/11.3.0) - 2026-06-24
 


### PR DESCRIPTION
## Description

Remove changelog entries that were added after v11.3.0. These entries should no longer be maintained in the changelog, as the GitHub release notes are now the source of truth for the latest changes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

No tests required. This change only removes changelog entries.

## Integration Instructions

N/A
