### PR TITLE
docs(practices-ng-forms): add Signal Forms compatibility matrix

### DIFF
--- a/ng/practices-ng-forms/docs/signal-forms-compatibility.md
+++ b/ng/practices-ng-forms/docs/signal-forms-compatibility.md
@@ -54,51 +54,57 @@ is not a percentage compatibility claim.
 
 | Surface | Existing `practices-ng-forms` | Angular Signal Forms | Status and consequence |
 | --- | --- | --- | --- |
-| Factory and builder | `formGroup.withBuilder`, `withType`, `withResetFromSignal`, plus direct factory functions. | `form(modelSignal, schemaOrOptions?)` returns a `FieldTree`. | **Intentional model difference.** Preserve the fluent API; do not invent a `formSignal.withBuilder` name. |
-| Source of truth | `FormGroup`/`FormControl` own the value; `valueSignal` and control signals are projections. | A user-owned writable signal owns the model; field writes update that signal. | **Not drop-in.** An adapter must define ownership and write-back rules first. |
-| Controls and groups | Strongly typed `FormGroup`/`FormControl` definitions and nested group typing. | A field tree mirrors plain object structure and exposes callable field state. | **Partial parity.** Nested object paths are conceptually mappable, but the runtime objects and mutation APIs differ. |
+| Factory and builder | `formGroup.withBuilder`, `withType`, `withResetFromSignal`, plus direct factory functions. | `form(modelSignal, schemaOrOptions?)` returns a `FieldTree`. | **Compatibility shim required.** Keep the existing names and call shapes; translate their definitions to a Signal Forms model/schema internally. Do not invent a parallel `formSignal.withBuilder` migration API. |
+| Source of truth | `FormGroup`/`FormControl` own the value; `valueSignal` and control signals are projections. | A user-owned writable signal owns the model; field writes update that signal. | **Drop-in requirement.** Signal ownership may change internally, but existing reads, writes, resets, and signal projections must retain their current behavior. |
+| Controls and groups | Strongly typed `FormGroup`/`FormControl` definitions and nested group typing. | A field tree mirrors plain object structure and exposes callable field state. | **Compatibility facade.** Translate existing nested definitions to a field tree while preserving the current builder return shape and methods. |
 | Arrays | `FormControlArrayValues` exists as a type helper, but the builder and validator paths are FormGroup-oriented; no public FormArray factory is exported. | Arrays are first-class field-tree nodes with stable field identity for iteration. | **Gap.** Array creation, replacement, identity, and validation need explicit contract tests. |
-| Initial values and reset | `value`, `nullable`, `nonNullable`, dynamic definition updates, and `reset()` on Reactive Forms controls. | Initial model is a writable signal; field state exposes signal-based value mutation and reset behavior. | **Intentional difference to measure.** Define whether reset means model replacement, field-state reset, or both. |
-| Disabled and availability | `disabled` is a control-definition option; runtime uses `disable()`/`enable()`. Disabled controls follow Reactive Forms aggregation rules. | `disabled()`, `hidden()`, and `readonly()` are schema rules with field-state signals; non-interactive fields have distinct parent-state behavior. | **Semantic difference.** Do not map these by name alone; test value inclusion and parent validity/state. |
-| Dirty and touched | `dirtySignal`, `pristineSignal`, `touchedSignal`, and `untouchedSignal` are derived from Reactive Forms status/events. | `dirty()` and `touched()` are field-state signals with documented interaction semantics and programmatic marking. | **Likely adapter surface, not parity yet.** Test programmatic marking, disabled/readonly fields, and edit-then-revert behavior. |
+| Initial values and reset | `value`, `nullable`, `nonNullable`, dynamic definition updates, and `reset()` on Reactive Forms controls. | Initial model is a writable signal; field state exposes signal-based value mutation and reset behavior. | **Legacy behavior is authoritative.** Preserve current reset, nullability, and dynamic-definition semantics while synchronizing the Signal Forms model. |
+| Disabled and availability | `disabled` is a control-definition option; runtime uses `disable()`/`enable()`. Disabled controls follow Reactive Forms aggregation rules. | `disabled()`, `hidden()`, and `readonly()` are schema rules with field-state signals; non-interactive fields have distinct parent-state behavior. | **Compatibility mapping.** Keep existing `disable()`/`enable()` and aggregate-value behavior for old callers; map the richer Signal Forms availability state without surprising them. |
+| Dirty and touched | `dirtySignal`, `pristineSignal`, `touchedSignal`, and `untouchedSignal` are derived from Reactive Forms status/events. | `dirty()` and `touched()` are field-state signals with documented interaction semantics and programmatic marking. | **Compatibility mapping.** Existing state transitions and programmatic methods remain authoritative; add contract tests for disabled/readonly fields and edit-then-revert behavior. |
 | Validity and pending state | `statusSignal`, `validSignal`, and `invalidSignal`; async validators use Angular `AsyncValidatorFn`. | `valid()`, `invalid()`, `pending()`, and `errors()` live on `FieldState`. | **Partial parity.** Pending and error-shape conversion are required before any compatibility claim. |
-| Validators | Validator arrays plus `conditional`, `dependent`, `async`, `asyncConditional`, and multi-field validation extensions. | Schema/path rules such as `required`, `email`, `validate`, conditional logic, and field-context access (`valueOf`, `stateOf`, `fieldTreeOf`). | **Conceptual overlap with different binding model.** Make validator translation explicit and preserve message/error provenance. |
+| Validators | Validator arrays plus `conditional`, `dependent`, `async`, `asyncConditional`, and multi-field validation extensions. | Schema/path rules such as `required`, `email`, `validate`, conditional logic, and field-context access (`valueOf`, `stateOf`, `fieldTreeOf`). | **Dual-input requirement.** The compatibility layer must accept existing `ValidatorFn`/`AsyncValidatorFn` functions and new Signal Forms schema/path validators, including mixed definitions, while preserving error/message provenance. |
 | Async validation | Supported through `AsyncValidatorFn` and conditional effect helpers. | Signal Forms documents pending state and schema-based async validation behavior. | **Unknown until measured.** Test cancellation, pending transitions, stale responses, and error routing independently. |
-| Submission | Submission is composed with `practices-ng-commands` and `PuiFormStateService`; the forms package has no `submit()`/`FormRoot` equivalent. | `submit()` validates, marks interactive fields touched, runs an action, routes returned errors, and returns `Promise<boolean>`; `FormRoot` wires form submission. | **Gap.** Submission behavior should be a separate focused slice, not hidden inside a builder adapter. |
+| Submission | Submission is composed with `practices-ng-commands` and `PuiFormStateService`; the forms package has no `submit()`/`FormRoot` equivalent. | `submit()` validates, marks interactive fields touched, runs an action, routes returned errors, and returns `Promise<boolean>`; `FormRoot` wires form submission. | **Additive compatibility.** Keep existing command/service submission behavior unchanged and expose Signal Forms submission as an additive path. |
 | Template directives | `[formGroup][puiForm]`, `[puiFormField]`, readonly behavior, and CVA-oriented wrapper providers. | `[formField]` binds a `FieldTree`; `[formRoot]` handles form submission; custom controls prefer Signal Forms control interfaces while CVA is supported for backwards compatibility. | **Separate template surface.** Existing directives must remain unchanged; adapters need explicit imports and examples. |
-| Errors | Angular `ValidationErrors | null`, control-level errors, and DOM-oriented invalid-control lookup. | `errors()` returns field-state error objects, including messages and targets for submission errors. | **Representation difference.** Define a lossless mapping or document intentional loss; do not silently stringify errors. |
+| Errors | Angular `ValidationErrors | null`, control-level errors, and DOM-oriented invalid-control lookup. | `errors()` returns field-state error objects, including messages and targets for submission errors. | **Compatibility mapping.** Preserve `ValidationErrors` for existing callers while retaining Signal Forms messages and targets for new callers. |
 | Value/status observation | RxJS `valueChanges`/`statusChanges` are converted with `toSignal`; utilities also expose filtered/debounced signals and RxJS interop. | Model and field state are signal-first; RxJS is not the source-of-truth contract. | **Optional interop.** Keep RxJS support for the existing package; do not make it a hidden Signal Forms requirement. |
 | Custom controls | `provideWrappedFormControlAccessors` combines CVA and validator providers around an underlying Reactive Forms control. | `FormField` supports native controls, Signal Forms control interfaces, and CVA for backwards compatibility. | **Integration point.** A wrapper can be useful, but interface and lifecycle behavior require dedicated tests. |
-| Angular/compiler support | Package peers currently stop before Angular 22; development/test dependencies are Angular 19.2.18. | Stable APIs are documented from Angular 22.0; the overview requires Angular 21+. | **Boundary blocker.** A single package cannot honestly promise existing Angular 18-21 support and stable Signal Forms support without an isolated build/version contract. |
+| Angular/compiler support | Package peers currently stop before Angular 22; development/test dependencies are Angular 19.2.18. | Stable APIs are documented from Angular 22.0; the overview requires Angular 21+. | **Compatibility constraint.** Keep the package and migration path unified; use an internal isolated entrypoint/build only if the compiler cannot support both lanes, and prove the peer/version contract before changing metadata. |
 
 ## Package-boundary decision
 
-The evidence does not support adding Signal Forms directly to the existing root
-API in the next implementation slice. The package already has a forms-related
-home and already uses signals, but three boundaries are material:
+The migration target is an in-package compatibility layer, not a new migration
+package. The existing `@nexplore/practices-ng-forms` root API remains the public
+entrypoint and the existing fluent builder remains the preferred user-facing
+path. Its implementation may be refactored so that `withBuilder`, `withType`,
+and `withResetFromSignal` construct and operate on Signal Forms equivalents while
+preserving the current return shape and behavior.
 
-1. The current public contract is built around Reactive Forms objects and must
-   keep its fluent builder behavior.
-2. The current peer range includes Angular 18-21 but excludes Angular 22, while
-   the stable Signal Forms APIs are documented from Angular 22. A static import
-   of `@angular/forms/signals` cannot be compiled and tested against the current
-   Angular 19 workspace without changing that baseline.
-3. Signal Forms changes the source of truth, template directives, error model,
-   submission lifecycle, and availability semantics. These are package-level
-   contracts, not a small internal refactor.
+The compatibility layer must provide both lanes:
 
-Therefore, a parallel Signal Forms package or an explicitly isolated secondary
-build is currently safer than changing `@nexplore/practices-ng-forms` in place.
-The exact package name and whether a secondary entrypoint can provide equivalent
-dependency isolation remain open design decisions. The existing package root
-and its fluent Reactive Forms API must remain stable either way.
+1. Existing Reactive Forms callers keep using the current validator functions,
+   including `ValidatorFn`, `AsyncValidatorFn`, `Validators.*`, conditional and
+   dependent helpers, without migration edits.
+2. Signal Forms callers can use schema/path validators and field-context logic,
+   including alongside legacy validators in one form definition. The adapter
+   normalizes the resulting state and errors without silently dropping messages,
+   async pending state, or field targets.
+
+Angular 19 development dependencies and the current peer range remain a real
+compiler/version constraint, but they are not by themselves a reason to force a
+parallel package. First prove an in-package build and secondary-entrypoint
+strategy that preserves the old Angular support lane. A separate package is a
+last-resort fallback only if compiler, public API, or peer-dependency isolation
+cannot be solved without increasing migration effort or breaking existing users.
 
 ## Next bounded slice
 
 Before implementation, add contract fixtures that exercise the matrix's highest-
-risk rows: arrays, disabled/readonly state, async validation cancellation,
+risk rows: the unchanged `withBuilder` call shape, mixed legacy and Signal Forms
+validators, arrays, disabled/readonly state, async validation cancellation,
 error mapping, and submission. The fixture must compile against the intended
-Angular 21/22 boundary and be isolated from the current Angular 19 workspace.
-Only after those contracts pass should a separate implementation PR choose a
-package name and add peer/build metadata. No runtime Signal Forms dependency is
-introduced by this matrix.
+Angular 21/22 boundary while proving that the existing Angular 18-20 lane still
+accepts the old API. Only after those contracts pass should the implementation
+refactor the existing package internals and, if necessary, add an isolated
+secondary entrypoint/build. No runtime Signal Forms dependency is introduced by
+this matrix.

--- a/ng/practices-ng-forms/docs/signal-forms-compatibility.md
+++ b/ng/practices-ng-forms/docs/signal-forms-compatibility.md
@@ -1,0 +1,104 @@
+# Signal Forms compatibility matrix
+
+Status: design evidence only. This document does not add a Signal Forms runtime
+dependency or claim API compatibility.
+
+Baseline: `origin/main` at `0027e3bfe58bf6447030b8850970c024bf3b559c`, inspected
+2026-08-18.
+
+## Official Angular position
+
+Angular's first-party documentation describes Signal Forms as a signal-backed
+form system built around `form(WritableSignal<TModel>, schema?)`, a navigable
+`FieldTree`, schema rules, and the `FormField` directive. The API reference marks
+`form`, `FormField`, and `FormRoot` stable since Angular v22.0. The overview still
+recommends Reactive Forms for existing reactive-form applications and for cases
+requiring production-stability guarantees. The overview lists Angular v21 or
+higher as the prerequisite, so v21 must be treated as a compatibility boundary,
+not as proof of v22-level stability.
+
+Sources:
+
+- [Signal Forms overview](https://angular.dev/guide/forms/signals/overview)
+- [`form` API](https://angular.dev/api/forms/signals/form)
+- [`FormField` API](https://angular.dev/api/forms/signals/FormField)
+- [`FormRoot` API](https://angular.dev/api/forms/signals/FormRoot)
+- [Signal Forms comparison](https://angular.dev/guide/forms/signals/comparison)
+- [Angular version compatibility](https://angular.dev/reference/versions)
+
+## Repository baseline
+
+The public entrypoint in `ng/practices-ng-forms/src/index.ts` exports:
+
+- the `formGroup` namespace, whose public factories are `withBuilder`,
+  `withType`, and `withResetFromSignal`;
+- direct factories `createFormGroup`, `createFormGroupWithType`, and
+  `createFormGroupWithResetFromSignal`;
+- Reactive Forms directives/providers, form-state services, RxJS/signal
+  utilities, and validators.
+
+The implementation in `src/lib/form-group-fluent-builder/extensions.ts` creates
+Angular `FormGroup` and `FormControl` instances, then adds signal views over
+Reactive Forms observables. The package currently develops against Angular
+19.2.18 and declares peers `@angular/common`, `@angular/core`, `@angular/forms`,
+and `@angular/router` as `>=18.0.0 <22.0.0` in
+`ng/practices-ng-forms/package.json`. It also requires RxJS `>=7.0.0 <8.0.0`.
+
+This means the existing package is intentionally a Reactive Forms package with
+signal interop, not an implementation of Angular's Signal Forms model.
+
+## Compatibility matrix
+
+The status column records the current evidence and the required next proof. It
+is not a percentage compatibility claim.
+
+| Surface | Existing `practices-ng-forms` | Angular Signal Forms | Status and consequence |
+| --- | --- | --- | --- |
+| Factory and builder | `formGroup.withBuilder`, `withType`, `withResetFromSignal`, plus direct factory functions. | `form(modelSignal, schemaOrOptions?)` returns a `FieldTree`. | **Intentional model difference.** Preserve the fluent API; do not invent a `formSignal.withBuilder` name. |
+| Source of truth | `FormGroup`/`FormControl` own the value; `valueSignal` and control signals are projections. | A user-owned writable signal owns the model; field writes update that signal. | **Not drop-in.** An adapter must define ownership and write-back rules first. |
+| Controls and groups | Strongly typed `FormGroup`/`FormControl` definitions and nested group typing. | A field tree mirrors plain object structure and exposes callable field state. | **Partial parity.** Nested object paths are conceptually mappable, but the runtime objects and mutation APIs differ. |
+| Arrays | `FormControlArrayValues` exists as a type helper, but the builder and validator paths are FormGroup-oriented; no public FormArray factory is exported. | Arrays are first-class field-tree nodes with stable field identity for iteration. | **Gap.** Array creation, replacement, identity, and validation need explicit contract tests. |
+| Initial values and reset | `value`, `nullable`, `nonNullable`, dynamic definition updates, and `reset()` on Reactive Forms controls. | Initial model is a writable signal; field state exposes signal-based value mutation and reset behavior. | **Intentional difference to measure.** Define whether reset means model replacement, field-state reset, or both. |
+| Disabled and availability | `disabled` is a control-definition option; runtime uses `disable()`/`enable()`. Disabled controls follow Reactive Forms aggregation rules. | `disabled()`, `hidden()`, and `readonly()` are schema rules with field-state signals; non-interactive fields have distinct parent-state behavior. | **Semantic difference.** Do not map these by name alone; test value inclusion and parent validity/state. |
+| Dirty and touched | `dirtySignal`, `pristineSignal`, `touchedSignal`, and `untouchedSignal` are derived from Reactive Forms status/events. | `dirty()` and `touched()` are field-state signals with documented interaction semantics and programmatic marking. | **Likely adapter surface, not parity yet.** Test programmatic marking, disabled/readonly fields, and edit-then-revert behavior. |
+| Validity and pending state | `statusSignal`, `validSignal`, and `invalidSignal`; async validators use Angular `AsyncValidatorFn`. | `valid()`, `invalid()`, `pending()`, and `errors()` live on `FieldState`. | **Partial parity.** Pending and error-shape conversion are required before any compatibility claim. |
+| Validators | Validator arrays plus `conditional`, `dependent`, `async`, `asyncConditional`, and multi-field validation extensions. | Schema/path rules such as `required`, `email`, `validate`, conditional logic, and field-context access (`valueOf`, `stateOf`, `fieldTreeOf`). | **Conceptual overlap with different binding model.** Make validator translation explicit and preserve message/error provenance. |
+| Async validation | Supported through `AsyncValidatorFn` and conditional effect helpers. | Signal Forms documents pending state and schema-based async validation behavior. | **Unknown until measured.** Test cancellation, pending transitions, stale responses, and error routing independently. |
+| Submission | Submission is composed with `practices-ng-commands` and `PuiFormStateService`; the forms package has no `submit()`/`FormRoot` equivalent. | `submit()` validates, marks interactive fields touched, runs an action, routes returned errors, and returns `Promise<boolean>`; `FormRoot` wires form submission. | **Gap.** Submission behavior should be a separate focused slice, not hidden inside a builder adapter. |
+| Template directives | `[formGroup][puiForm]`, `[puiFormField]`, readonly behavior, and CVA-oriented wrapper providers. | `[formField]` binds a `FieldTree`; `[formRoot]` handles form submission; custom controls prefer Signal Forms control interfaces while CVA is supported for backwards compatibility. | **Separate template surface.** Existing directives must remain unchanged; adapters need explicit imports and examples. |
+| Errors | Angular `ValidationErrors | null`, control-level errors, and DOM-oriented invalid-control lookup. | `errors()` returns field-state error objects, including messages and targets for submission errors. | **Representation difference.** Define a lossless mapping or document intentional loss; do not silently stringify errors. |
+| Value/status observation | RxJS `valueChanges`/`statusChanges` are converted with `toSignal`; utilities also expose filtered/debounced signals and RxJS interop. | Model and field state are signal-first; RxJS is not the source-of-truth contract. | **Optional interop.** Keep RxJS support for the existing package; do not make it a hidden Signal Forms requirement. |
+| Custom controls | `provideWrappedFormControlAccessors` combines CVA and validator providers around an underlying Reactive Forms control. | `FormField` supports native controls, Signal Forms control interfaces, and CVA for backwards compatibility. | **Integration point.** A wrapper can be useful, but interface and lifecycle behavior require dedicated tests. |
+| Angular/compiler support | Package peers currently stop before Angular 22; development/test dependencies are Angular 19.2.18. | Stable APIs are documented from Angular 22.0; the overview requires Angular 21+. | **Boundary blocker.** A single package cannot honestly promise existing Angular 18-21 support and stable Signal Forms support without an isolated build/version contract. |
+
+## Package-boundary decision
+
+The evidence does not support adding Signal Forms directly to the existing root
+API in the next implementation slice. The package already has a forms-related
+home and already uses signals, but three boundaries are material:
+
+1. The current public contract is built around Reactive Forms objects and must
+   keep its fluent builder behavior.
+2. The current peer range includes Angular 18-21 but excludes Angular 22, while
+   the stable Signal Forms APIs are documented from Angular 22. A static import
+   of `@angular/forms/signals` cannot be compiled and tested against the current
+   Angular 19 workspace without changing that baseline.
+3. Signal Forms changes the source of truth, template directives, error model,
+   submission lifecycle, and availability semantics. These are package-level
+   contracts, not a small internal refactor.
+
+Therefore, a parallel Signal Forms package or an explicitly isolated secondary
+build is currently safer than changing `@nexplore/practices-ng-forms` in place.
+The exact package name and whether a secondary entrypoint can provide equivalent
+dependency isolation remain open design decisions. The existing package root
+and its fluent Reactive Forms API must remain stable either way.
+
+## Next bounded slice
+
+Before implementation, add contract fixtures that exercise the matrix's highest-
+risk rows: arrays, disabled/readonly state, async validation cancellation,
+error mapping, and submission. The fixture must compile against the intended
+Angular 21/22 boundary and be isolated from the current Angular 19 workspace.
+Only after those contracts pass should a separate implementation PR choose a
+package name and add peer/build metadata. No runtime Signal Forms dependency is
+introduced by this matrix.

--- a/ng/practices-ng-forms/docs/signal-forms-compatibility.md
+++ b/ng/practices-ng-forms/docs/signal-forms-compatibility.md
@@ -29,7 +29,7 @@ Sources:
 - [Signal Forms comparison](https://angular.dev/guide/forms/signals/comparison)
 - [Angular version compatibility](https://angular.dev/reference/versions)
 - [Angular versioning and releases](https://angular.dev/reference/releases)
-- [Angular 22.1.3 release](https://github.com/angular/angular/releases/tag/22.1.3)
+- [Angular 22.1.3 release](https://github.com/angular/angular/releases/tag/v22.1.3)
 
 The migration guide now documents two stable v22 compatibility primitives. `compatForm`
 can wrap a model signal containing existing `FormControl` or `FormGroup` instances while

--- a/ng/practices-ng-forms/docs/signal-forms-compatibility.md
+++ b/ng/practices-ng-forms/docs/signal-forms-compatibility.md
@@ -20,11 +20,28 @@ not as proof of v22-level stability.
 Sources:
 
 - [Signal Forms overview](https://angular.dev/guide/forms/signals/overview)
+- [Migrating existing forms to Signal Forms](https://angular.dev/guide/forms/signals/migration)
 - [`form` API](https://angular.dev/api/forms/signals/form)
+- [`compatForm` API](https://angular.dev/api/forms/signals/compat/compatForm)
+- [`SignalFormControl` API](https://angular.dev/api/forms/signals/compat/SignalFormControl)
 - [`FormField` API](https://angular.dev/api/forms/signals/FormField)
 - [`FormRoot` API](https://angular.dev/api/forms/signals/FormRoot)
 - [Signal Forms comparison](https://angular.dev/guide/forms/signals/comparison)
 - [Angular version compatibility](https://angular.dev/reference/versions)
+- [Angular versioning and releases](https://angular.dev/reference/releases)
+
+The migration guide now documents two stable v22 compatibility primitives. `compatForm`
+can wrap a model signal containing existing `FormControl` or `FormGroup` instances while
+Signal Forms rules apply to other paths. `SignalFormControl` can expose a signal-backed
+leaf inside an existing `FormGroup`. This is the official interoperability baseline for
+minimal migration effort; it is not evidence that every Reactive Forms API has a Signal
+Forms equivalent. The same guide documents that `SignalFormControl` intentionally does
+not support imperative `disable()`/`enable()`, dynamic validator mutation, `setErrors()`,
+or `markAsPending()`. Those differences must remain explicit compatibility boundaries.
+
+Angular's release documentation treats `next` and release-candidate builds as previews
+that may change outside the normal stability policy. Preview-only forms behavior must not
+become a required package contract.
 
 ## Repository baseline
 
@@ -54,41 +71,44 @@ is not a percentage compatibility claim.
 
 | Surface | Existing `practices-ng-forms` | Angular Signal Forms | Status and consequence |
 | --- | --- | --- | --- |
-| Factory and builder | `formGroup.withBuilder`, `withType`, `withResetFromSignal`, plus direct factory functions. | `form(modelSignal, schemaOrOptions?)` returns a `FieldTree`. | **Compatibility shim required.** Keep the existing names and call shapes; translate their definitions to a Signal Forms model/schema internally. Do not invent a parallel `formSignal.withBuilder` migration API. |
-| Source of truth | `FormGroup`/`FormControl` own the value; `valueSignal` and control signals are projections. | A user-owned writable signal owns the model; field writes update that signal. | **Drop-in requirement.** Signal ownership may change internally, but existing reads, writes, resets, and signal projections must retain their current behavior. |
+| Factory and builder | `formGroup.withBuilder`, `withType`, `withResetFromSignal`, plus direct factory functions. | `form(modelSignal, schemaOrOptions?)` returns a `FieldTree`; `compatForm` accepts Reactive Forms controls in the model; `SignalFormControl` embeds a signal-backed leaf in a `FormGroup`. | **Compatibility shim required.** Keep the existing names and call shapes. Prefer the official `compatForm`/`SignalFormControl` bridge around existing controls before translating definitions. Do not invent a parallel `formSignal.withBuilder` migration API. |
+| Source of truth | `FormGroup`/`FormControl` own the value; `valueSignal` and control signals are projections. | A user-owned writable signal owns the model; `compatForm` can retain a nested Reactive Forms control as a model entry. | **Drop-in requirement.** Preserve existing reads, writes, resets, and signal projections. Do not silently replace a caller-owned control with a different source of truth. |
 | Controls and groups | Strongly typed `FormGroup`/`FormControl` definitions and nested group typing. | A field tree mirrors plain object structure and exposes callable field state. | **Compatibility facade.** Translate existing nested definitions to a field tree while preserving the current builder return shape and methods. |
 | Arrays | `FormControlArrayValues` exists as a type helper, but the builder and validator paths are FormGroup-oriented; no public FormArray factory is exported. | Arrays are first-class field-tree nodes with stable field identity for iteration. | **Gap.** Array creation, replacement, identity, and validation need explicit contract tests. |
 | Initial values and reset | `value`, `nullable`, `nonNullable`, dynamic definition updates, and `reset()` on Reactive Forms controls. | Initial model is a writable signal; field state exposes signal-based value mutation and reset behavior. | **Legacy behavior is authoritative.** Preserve current reset, nullability, and dynamic-definition semantics while synchronizing the Signal Forms model. |
-| Disabled and availability | `disabled` is a control-definition option; runtime uses `disable()`/`enable()`. Disabled controls follow Reactive Forms aggregation rules. | `disabled()`, `hidden()`, and `readonly()` are schema rules with field-state signals; non-interactive fields have distinct parent-state behavior. | **Compatibility mapping.** Keep existing `disable()`/`enable()` and aggregate-value behavior for old callers; map the richer Signal Forms availability state without surprising them. |
+| Disabled and availability | `disabled` is a control-definition option; runtime uses `disable()`/`enable()`. Disabled controls follow Reactive Forms aggregation rules. | `disabled()`, `hidden()`, and `readonly()` are schema rules with field-state signals; `SignalFormControl` intentionally rejects imperative `disable()`/`enable()`. | **Compatibility mapping.** Keep existing `disable()`/`enable()` and aggregate-value behavior for old callers. Do not expose the `SignalFormControl` limitation as a silent behavior change; use declarative rules for the signal-backed lane. |
 | Dirty and touched | `dirtySignal`, `pristineSignal`, `touchedSignal`, and `untouchedSignal` are derived from Reactive Forms status/events. | `dirty()` and `touched()` are field-state signals with documented interaction semantics and programmatic marking. | **Compatibility mapping.** Existing state transitions and programmatic methods remain authoritative; add contract tests for disabled/readonly fields and edit-then-revert behavior. |
 | Validity and pending state | `statusSignal`, `validSignal`, and `invalidSignal`; async validators use Angular `AsyncValidatorFn`. | `valid()`, `invalid()`, `pending()`, and `errors()` live on `FieldState`. | **Partial parity.** Pending and error-shape conversion are required before any compatibility claim. |
-| Validators | Validator arrays plus `conditional`, `dependent`, `async`, `asyncConditional`, and multi-field validation extensions. | Schema/path rules such as `required`, `email`, `validate`, conditional logic, and field-context access (`valueOf`, `stateOf`, `fieldTreeOf`). | **Dual-input requirement.** The compatibility layer must accept existing `ValidatorFn`/`AsyncValidatorFn` functions and new Signal Forms schema/path validators, including mixed definitions, while preserving error/message provenance. |
+| Validators | Validator arrays plus `conditional`, `dependent`, `async`, `asyncConditional`, and multi-field validation extensions. | Schema/path rules such as `required`, `email`, `validate`, conditional logic, and field-context access (`valueOf`, `stateOf`, `fieldTreeOf`). `compatForm` preserves validators on wrapped Reactive Forms controls. | **Interop first.** Preserve existing `ValidatorFn`/`AsyncValidatorFn` functions on existing controls and allow Signal Forms rules on other schema paths. Do not require same-control dual registration or rewrite every legacy validator until a measured contract proves it is necessary. |
 | Async validation | Supported through `AsyncValidatorFn` and conditional effect helpers. | Signal Forms documents pending state and schema-based async validation behavior. | **Unknown until measured.** Test cancellation, pending transitions, stale responses, and error routing independently. |
 | Submission | Submission is composed with `practices-ng-commands` and `PuiFormStateService`; the forms package has no `submit()`/`FormRoot` equivalent. | `submit()` validates, marks interactive fields touched, runs an action, routes returned errors, and returns `Promise<boolean>`; `FormRoot` wires form submission. | **Additive compatibility.** Keep existing command/service submission behavior unchanged and expose Signal Forms submission as an additive path. |
 | Template directives | `[formGroup][puiForm]`, `[puiFormField]`, readonly behavior, and CVA-oriented wrapper providers. | `[formField]` binds a `FieldTree`; `[formRoot]` handles form submission; custom controls prefer Signal Forms control interfaces while CVA is supported for backwards compatibility. | **Separate template surface.** Existing directives must remain unchanged; adapters need explicit imports and examples. |
 | Errors | Angular `ValidationErrors | null`, control-level errors, and DOM-oriented invalid-control lookup. | `errors()` returns field-state error objects, including messages and targets for submission errors. | **Compatibility mapping.** Preserve `ValidationErrors` for existing callers while retaining Signal Forms messages and targets for new callers. |
 | Value/status observation | RxJS `valueChanges`/`statusChanges` are converted with `toSignal`; utilities also expose filtered/debounced signals and RxJS interop. | Model and field state are signal-first; RxJS is not the source-of-truth contract. | **Optional interop.** Keep RxJS support for the existing package; do not make it a hidden Signal Forms requirement. |
 | Custom controls | `provideWrappedFormControlAccessors` combines CVA and validator providers around an underlying Reactive Forms control. | `FormField` supports native controls, Signal Forms control interfaces, and CVA for backwards compatibility. | **Integration point.** A wrapper can be useful, but interface and lifecycle behavior require dedicated tests. |
-| Angular/compiler support | Package peers currently stop before Angular 22; development/test dependencies are Angular 19.2.18. | Stable APIs are documented from Angular 22.0; the overview requires Angular 21+. | **Compatibility constraint.** Keep the package and migration path unified; use an internal isolated entrypoint/build only if the compiler cannot support both lanes, and prove the peer/version contract before changing metadata. |
+| Angular/compiler support | Package peers currently stop before Angular 22; development/test dependencies are Angular 19.2.18. | Stable Signal Forms and compatibility APIs are documented from Angular 22.0; the overview requires Angular 21+. | **Compatibility constraint.** Keep the package and migration path unified; first prove an Angular 22 compatibility lane using the official bridge while retaining the existing Angular 18-21 implementation. Prove the peer/version contract before changing metadata. |
 
 ## Package-boundary decision
 
 The migration target is an in-package compatibility layer, not a new migration
 package. The existing `@nexplore/practices-ng-forms` root API remains the public
 entrypoint and the existing fluent builder remains the preferred user-facing
-path. Its implementation may be refactored so that `withBuilder`, `withType`,
-and `withResetFromSignal` construct and operate on Signal Forms equivalents while
-preserving the current return shape and behavior.
+path. The first implementation path should compose the current Reactive Forms
+controls with Angular's stable `compatForm` bridge, and use `SignalFormControl`
+only where a signal-backed leaf is needed. Refactoring `withBuilder`, `withType`,
+and `withResetFromSignal` to construct a different control model is a later option,
+not a prerequisite for drop-in migration.
 
 The compatibility layer must provide both lanes:
 
 1. Existing Reactive Forms callers keep using the current validator functions,
    including `ValidatorFn`, `AsyncValidatorFn`, `Validators.*`, conditional and
-   dependent helpers, without migration edits.
-2. Signal Forms callers can use schema/path validators and field-context logic,
-   including alongside legacy validators in one form definition. The adapter
-   normalizes the resulting state and errors without silently dropping messages,
-   async pending state, or field targets.
+   dependent helpers, without migration edits. Where a caller opts into Signal
+   Forms, `compatForm` must preserve those controls and their validator behavior.
+2. Signal Forms callers can use schema/path validators and field-context logic on
+   the new signal-backed paths. Mixed models are supported through the official
+   bridge, but the adapter must not imply unsupported same-control dual registration
+   or silently drop messages, async pending state, or field targets.
 
 Angular 19 development dependencies and the current peer range remain a real
 compiler/version constraint, but they are not by themselves a reason to force a
@@ -99,12 +119,13 @@ cannot be solved without increasing migration effort or breaking existing users.
 
 ## Next bounded slice
 
-Before implementation, add contract fixtures that exercise the matrix's highest-
-risk rows: the unchanged `withBuilder` call shape, mixed legacy and Signal Forms
-validators, arrays, disabled/readonly state, async validation cancellation,
-error mapping, and submission. The fixture must compile against the intended
-Angular 21/22 boundary while proving that the existing Angular 18-20 lane still
-accepts the old API. Only after those contracts pass should the implementation
-refactor the existing package internals and, if necessary, add an isolated
-secondary entrypoint/build. No runtime Signal Forms dependency is introduced by
-this matrix.
+Before implementation, add contract fixtures that exercise the official bridge:
+an existing `FormControl`/`FormGroup` with legacy validators nested in `compatForm`,
+a `SignalFormControl` leaf inside a `FormGroup`, bidirectional value/state/error
+observation, and the documented imperative-API limitations. Then cover the unchanged
+`withBuilder` call shape, arrays, disabled/readonly state, async cancellation, error
+mapping, and submission. The fixture must compile against the intended Angular 21/22
+boundary while proving that the existing Angular 18-20 lane still accepts the old API.
+Only after those contracts pass should the implementation add a narrow adapter around
+the existing package internals or, if necessary, an isolated secondary entrypoint/build.
+No runtime Signal Forms dependency is introduced by this matrix.

--- a/ng/practices-ng-forms/docs/signal-forms-compatibility.md
+++ b/ng/practices-ng-forms/docs/signal-forms-compatibility.md
@@ -134,7 +134,7 @@ a `SignalFormControl` leaf inside a `FormGroup`, bidirectional value/state/error
 observation, and the documented imperative-API limitations. Then cover the unchanged
 `withBuilder` call shape, arrays, disabled/readonly state, async cancellation, error
 mapping, and submission. The fixture must compile against the intended Angular 21/22
-boundary while proving that the existing Angular 18-20 lane still accepts the old API.
+boundary while proving that the existing Angular 18-21 lane still accepts the old API.
 Only after those contracts pass should the implementation add a narrow adapter around
 the existing package internals or, if necessary, an isolated secondary entrypoint/build.
 No runtime Signal Forms dependency is introduced by this matrix.

--- a/ng/practices-ng-forms/docs/signal-forms-compatibility.md
+++ b/ng/practices-ng-forms/docs/signal-forms-compatibility.md
@@ -4,7 +4,7 @@ Status: design evidence only. This document does not add a Signal Forms runtime
 dependency or claim API compatibility.
 
 Baseline: `origin/main` at `0027e3bfe58bf6447030b8850970c024bf3b559c`, inspected
-2026-08-18.
+2026-08-19.
 
 ## Official Angular position
 
@@ -42,6 +42,12 @@ or `markAsPending()`. Those differences must remain explicit compatibility bound
 Angular's release documentation treats `next` and release-candidate builds as previews
 that may change outside the normal stability policy. Preview-only forms behavior must not
 become a required package contract.
+
+Angular `22.1.0` is now the latest stable minor in the v22 line. The Angular release
+listing also shows a forms change, "allow permanent hidden fields", in `22.2.0-next.0`.
+That change is a preview-only signal, so this package must not depend on it or describe it
+as part of the compatibility target until it reaches a stable release and the repository
+has a focused contract for the behavior.
 
 ## Repository baseline
 

--- a/ng/practices-ng-forms/docs/signal-forms-compatibility.md
+++ b/ng/practices-ng-forms/docs/signal-forms-compatibility.md
@@ -4,7 +4,7 @@ Status: design evidence only. This document does not add a Signal Forms runtime
 dependency or claim API compatibility.
 
 Baseline: `origin/main` at `0027e3bfe58bf6447030b8850970c024bf3b559c`, inspected
-2026-08-19.
+2026-08-20.
 
 ## Official Angular position
 
@@ -29,6 +29,7 @@ Sources:
 - [Signal Forms comparison](https://angular.dev/guide/forms/signals/comparison)
 - [Angular version compatibility](https://angular.dev/reference/versions)
 - [Angular versioning and releases](https://angular.dev/reference/releases)
+- [Angular 22.1.3 release](https://github.com/angular/angular/releases/tag/22.1.3)
 
 The migration guide now documents two stable v22 compatibility primitives. `compatForm`
 can wrap a model signal containing existing `FormControl` or `FormGroup` instances while
@@ -43,11 +44,13 @@ Angular's release documentation treats `next` and release-candidate builds as pr
 that may change outside the normal stability policy. Preview-only forms behavior must not
 become a required package contract.
 
-Angular `22.1.0` is now the latest stable minor in the v22 line. The Angular release
-listing also shows a forms change, "allow permanent hidden fields", in `22.2.0-next.0`.
-That change is a preview-only signal, so this package must not depend on it or describe it
-as part of the compatibility target until it reaches a stable release and the repository
-has a focused contract for the behavior.
+Angular `22.1.3` is the latest stable v22 release inspected for this checkpoint. Its
+Forms changes include reporting forbidden two-way bindings when `FormField` is applied;
+the compatibility layer must preserve that one-way `formField` binding contract and must
+not introduce a mixed `[(ngModel)]`/`[formField]` example. The release listing currently
+shows `22.2.0-next.3` as a pre-release, so preview-only Forms behavior in that line must
+not become a required package contract until it reaches a stable release and the
+repository has a focused contract for the behavior.
 
 ## Repository baseline
 
@@ -88,7 +91,7 @@ is not a percentage compatibility claim.
 | Validators | Validator arrays plus `conditional`, `dependent`, `async`, `asyncConditional`, and multi-field validation extensions. | Schema/path rules such as `required`, `email`, `validate`, conditional logic, and field-context access (`valueOf`, `stateOf`, `fieldTreeOf`). `compatForm` preserves validators on wrapped Reactive Forms controls. | **Interop first.** Preserve existing `ValidatorFn`/`AsyncValidatorFn` functions on existing controls and allow Signal Forms rules on other schema paths. Do not require same-control dual registration or rewrite every legacy validator until a measured contract proves it is necessary. |
 | Async validation | Supported through `AsyncValidatorFn` and conditional effect helpers. | Signal Forms documents pending state and schema-based async validation behavior. | **Unknown until measured.** Test cancellation, pending transitions, stale responses, and error routing independently. |
 | Submission | Submission is composed with `practices-ng-commands` and `PuiFormStateService`; the forms package has no `submit()`/`FormRoot` equivalent. | `submit()` validates, marks interactive fields touched, runs an action, routes returned errors, and returns `Promise<boolean>`; `FormRoot` wires form submission. | **Additive compatibility.** Keep existing command/service submission behavior unchanged and expose Signal Forms submission as an additive path. |
-| Template directives | `[formGroup][puiForm]`, `[puiFormField]`, readonly behavior, and CVA-oriented wrapper providers. | `[formField]` binds a `FieldTree`; `[formRoot]` handles form submission; custom controls prefer Signal Forms control interfaces while CVA is supported for backwards compatibility. | **Separate template surface.** Existing directives must remain unchanged; adapters need explicit imports and examples. |
+| Template directives | `[formGroup][puiForm]`, `[puiFormField]`, readonly behavior, and CVA-oriented wrapper providers. | `[formField]` binds a `FieldTree`; `[formRoot]` handles form submission; custom controls prefer Signal Forms control interfaces while CVA is supported for backwards compatibility. Angular 22.1.3 reports forbidden two-way bindings when `FormField` is applied. | **Separate template surface.** Existing directives must remain unchanged; adapters need explicit imports and examples. Signal Forms examples must use one-way `[formField]` binding and must not combine it with `[(ngModel)]`. |
 | Errors | Angular `ValidationErrors | null`, control-level errors, and DOM-oriented invalid-control lookup. | `errors()` returns field-state error objects, including messages and targets for submission errors. | **Compatibility mapping.** Preserve `ValidationErrors` for existing callers while retaining Signal Forms messages and targets for new callers. |
 | Value/status observation | RxJS `valueChanges`/`statusChanges` are converted with `toSignal`; utilities also expose filtered/debounced signals and RxJS interop. | Model and field state are signal-first; RxJS is not the source-of-truth contract. | **Optional interop.** Keep RxJS support for the existing package; do not make it a hidden Signal Forms requirement. |
 | Custom controls | `provideWrappedFormControlAccessors` combines CVA and validator providers around an underlying Reactive Forms control. | `FormField` supports native controls, Signal Forms control interfaces, and CVA for backwards compatibility. | **Integration point.** A wrapper can be useful, but interface and lifecycle behavior require dedicated tests. |


### PR DESCRIPTION
🤖

## Problem

Angular Signal Forms is a distinct signal-backed forms system, but migration must remain drop-in: existing applications should keep their current `@nexplore/practices-ng-forms` names, builder calls, validator functions, state behavior, and submission integrations.

## Baseline and compatibility decision

- Baseline: `main` at `0027e3bfe58bf6447030b8850970c024bf3b559c`
- Keep `formGroup.withBuilder`, `withType`, `withResetFromSignal`, and direct factories as compatibility shims.
- The first implementation path should compose existing Reactive Forms controls with the stable v22 `compatForm` bridge, using `SignalFormControl` only for signal-backed leaves where needed.
- Existing `ValidatorFn`, `AsyncValidatorFn`, `Validators.*`, conditional/dependent helpers, and Signal Forms schema/path validators must coexist through the documented interop boundary without implying unsupported same-control dual registration.
- A parallel package is a last resort only if an internal isolated entrypoint/build cannot preserve the existing Angular support lane.

## Scope

- Added and maintained `ng/practices-ng-forms/docs/signal-forms-compatibility.md` as design evidence for the public API, behavior, package boundary, and contract-fixture sequence.
- Recorded the official v22 `compatForm` and `SignalFormControl` interoperability baseline and documented their imperative-API limitations.
- Recorded Angular `22.1.3` as the latest stable v22 release inspected on 2026-08-20, including its Forms guard for forbidden two-way bindings when `FormField` is applied.
- Kept the current `22.2.0-next.3` line explicitly preview-only and non-required.
- The matrix covers builder translation, legacy/new validator coexistence, arrays, reset/nullability, disabled/touched/dirty behavior, submission, template directives, error mapping, custom controls, RxJS interop, and Angular version constraints.

## Verification

Automated checks and repository review are reflected in the current pull-request state. Detailed execution records are kept privately.

## Residual risk

This remains design evidence, not an implementation or compatibility claim. The next slice must prove the official bridge with an existing `FormControl`/`FormGroup` nested in `compatForm`, a `SignalFormControl` leaf inside a `FormGroup`, bidirectional value/state/error observation, and the documented imperative-API limitations before any package metadata or builder internals change.

## Follow-up

- Corrected the next-slice wording to state the existing Angular 18-21 support lane explicitly; no runtime or package metadata change was made.