### PR TITLE
Fix Reactive Forms compatibility contract failures

### DIFF
--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts
@@ -76,9 +76,8 @@ function updateFormGroupDefinition(
             if (controlDef instanceof AbstractControl) {
                 formGroup.addControl(key, controlDef, { emitEvent: options.emitChangeEvents });
             } else {
-                const existingControl = formGroup.get(key);
+                const existingControl = formGroup.controls[key];
                 if (existingControl) {
-
                     const needsToRecreateControl =
                         (controlDef.updateOn ?? existingControl.updateOn) !== existingControl.updateOn;
 

--- a/ng/practices-ng-forms/src/lib/form-group-fluent-builder/reactive-forms-compat-contract.spec.ts
+++ b/ng/practices-ng-forms/src/lib/form-group-fluent-builder/reactive-forms-compat-contract.spec.ts
@@ -62,9 +62,15 @@ describe('Reactive Forms compatibility contract', () => {
     it('preserves an omitted control value when a factory changes updateOn', () => {
         TestBed.runInInjectionContext(() => {
             const updateOn = signal<'change' | 'blur'>('change');
-            const formGroup = createExtendedFormGroup(() => ({
-                name: { value: 'initial', updateOn: updateOn() },
-            }));
+            const formGroup = createExtendedFormGroup(() => {
+                const currentUpdateOn = updateOn();
+                return {
+                    name:
+                        currentUpdateOn === 'change'
+                            ? { value: 'initial', updateOn: currentUpdateOn }
+                            : { updateOn: currentUpdateOn },
+                };
+            });
 
             TestBed.flushEffects();
             formGroup.controls.name.setValue('edited');


### PR DESCRIPTION
🤖

## Summary

Follow-up to [PR #70](https://github.com/nexplore/nexplore-practices/pull/70), based on exact original head `5516cc69db3c8b59b553c1280d344d592a087911`.

The Reactive Forms compatibility contract suite still failed because disabled controls were looked up through `contains()`, which excludes disabled controls, and the omitted-value test did not actually omit `value` after the factory signal changed. This focused fix uses `formGroup.controls[key]` for existing-control lookup and makes the test definition omit `value` on recreation.

## Verification

- Changed files: `ng/practices-ng-forms/src/lib/form-group-fluent-builder/extensions.ts` and `ng/practices-ng-forms/src/lib/form-group-fluent-builder/reactive-forms-compat-contract.spec.ts`.
- `git diff --check` passed.
- Focused Nx test is unavailable locally because `./ng/node_modules/.bin/nx` is absent.
- Build & Test is running for this exact head; compatibility is not claimed until it passes.

## Residual risk

The fix is limited to existing-control lookup and the regression fixture. The draft remains open for maintainer review.